### PR TITLE
Derive key from type when registering a provider

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,29 @@ PATH
   remote: .
   specs:
     oaken (0.2.0)
+      activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     minitest (5.18.1)
     minitest-sprint (1.2.2)
       path_expander (~> 1.1)
     path_expander (1.1.1)
     rake (13.0.6)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "oaken/version"
+require "active_support/core_ext/string/inflections"
+
+require "oaken/version"
 
 module Oaken
   class Error < StandardError; end
@@ -51,14 +53,14 @@ module Oaken
     extend self
 
     class Provider < Struct.new(:data, :provider)
-      def register(key, type)
-        stored = provider.new(type) and data.define_method(key) { stored }
+      def register(type)
+        stored = provider.new(type)
+        data.define_method(type.to_s.underscore.tr("/", "_").pluralize) { stored }
       end
     end
 
     def self.provider(name, provider)
       define_singleton_method(name) { (@providers ||= {})[name] ||= Provider.new(self, provider) }
-      class_eval "def #{name}; self.class.#{name}; end"
     end
 
     provider :memory, Stored::Memory

--- a/oaken.gemspec
+++ b/oaken.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "activesupport"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/seeds/comments.rb
+++ b/test/seeds/comments.rb
@@ -1,2 +1,2 @@
-Comment = Struct.new(:name, keyword_init: true)
-records.register :comments, Comment
+::Comment = Struct.new(:name, keyword_init: true)
+records.register Comment

--- a/test/seeds/users.rb
+++ b/test/seeds/users.rb
@@ -1,4 +1,4 @@
-User = Struct.new(:name, keyword_init: true)
-memory.register :users, User
+::User = Struct.new(:name, keyword_init: true)
+memory.register User
 
 users.update :kasper, name: "Kasper"


### PR DESCRIPTION
Before this commit, we had to manually specify the key when registering a provider:

```rb
records.register :comments, Comment # For ActiveRecord
memory.register :users, User        # For in-memory
```

We can derive the name of the key from the class of the object thanks to the ActiveSupport `underscore` and `pluralize` methods.

We can now register a provider without mentionning the key like this:

```rb
records.register Comment # For ActiveRecord
memory.register User     # For in-memory
```