### PR TITLE
Forgot to test that default attributes can be overriden

### DIFF
--- a/test/oaken_test.rb
+++ b/test/oaken_test.rb
@@ -24,13 +24,17 @@ class OakenTest < Oaken::Test
     assert_equal [users.kasper, users.coworker], accounts.business.users
   end
 
+  def test_default_attributes_override
+    assert_equal "Big Business Co.", accounts.business.name
+  end
+
   def test_default_attributes_last_into_test
     users.update :homer
     assert_equal [accounts.business], users.homer.accounts
   end
 
   def test_default_attributes_block
-    users.with accounts: [accounts.update(:home_co, name: "Yo")] do
+    users.with accounts: [accounts.update(:home_co)] do
       users.update :homer
     end
     assert_equal [accounts.home_co], users.homer.accounts

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -1,3 +1,4 @@
+accounts.with name: -> { id.to_s.humanize }
 accounts.update :business, name: "Big Business Co."
 
 users.with name: -> { id.to_s.capitalize }, accounts: [accounts.business]


### PR DESCRIPTION
Here the explicit `name` should in the `update` call should take precedence:

```ruby
accounts.with name: -> { id.to_s.humanize }
accounts.update :business, name: "Big Business Co."
```