### PR TITLE
Local test support for different database adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "minitest-sprint"
 
 gem "activerecord"
 gem "sqlite3"
+gem "mysql2"
+gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,9 @@ GEM
     minitest (5.18.1)
     minitest-sprint (1.2.2)
       path_expander (~> 1.1)
+    mysql2 (0.5.5)
     path_expander (1.1.1)
+    pg (1.5.3)
     rake (13.0.6)
     sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
@@ -38,7 +40,9 @@ DEPENDENCIES
   activerecord
   minitest (~> 5.0)
   minitest-sprint
+  mysql2
   oaken!
+  pg
   rake (~> 13.0)
   sqlite3
 


### PR DESCRIPTION
I'm going to be working on a caching scheme based off of seed file checksums, so prepping for that I'm working on having us test with persisted databases (not just the in-memory SQLite one we've got now) and every adapter. This works locally, but I still need to figure out CI setups.

I'm thinking we'll end up with something like:

- `bin/test all`
- `bin/test sqlite` — the default.
- `bin/test mysql`
- `bin/test postgres`

I also want our test runner to execute tests twice: first from a fresh database, and then run tests a second time after that to check both our uncached and cached states work.