### PR TITLE
Test helper methods

### DIFF
--- a/test/oaken_test.rb
+++ b/test/oaken_test.rb
@@ -15,6 +15,15 @@ class OakenTest < Oaken::Test
     refute_nil ::Oaken::VERSION
   end
 
+  def test_helper_methods
+    assert_equal 2, accounts.increment_counter # We start at 2 since the seeds file state should pass into here.
+    assert_equal 3, accounts.increment_counter
+
+    assert_raise NoMethodError do
+      users.increment_counter
+    end
+  end
+
   def test_fixture_yml_compatibility
     assert_equal "YAML", YamlRecord.first.name
     assert_equal accounts.business, YamlRecord.first.account

--- a/test/seeds/accounts/business.rb
+++ b/test/seeds/accounts/business.rb
@@ -1,4 +1,10 @@
 business = accounts.update :business, name: "Big Business Co."
 
+def accounts.increment_counter
+  @counter ||= 0
+  @counter += 1
+end
+accounts.increment_counter
+
 users.update :kasper,   name: "Kasper",   accounts: [business]
 users.update :coworker, name: "Coworker", accounts: [business]


### PR DESCRIPTION
Since our `accounts` and `users` are object instances we can leverage Ruby's singleton methods to define helpers:

```ruby
object = Object.new
def object.hello = "hello"

object.hello # => "hello"
object.singleton_methods # => [:hello]
```

We probably need to refine these some more, but I want to get the tests for these in first.