### PR TITLE
Remove fixture integration

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -69,26 +69,24 @@ module Oaken
 
   class Stored::ActiveRecord < Stored::Abstract
     def find(id)
-      @type.find identify id
+      @type.find id.hash
     end
 
     def update(id, **attributes)
       attributes = super
 
-      if record = @type.find_by(id: identify(id))
+      if record = @type.find_by(id: id.hash)
         record.tap { _1.update!(**attributes) }
       else
-        @type.create!(id: identify(id), **attributes)
+        @type.create!(id: id.hash, **attributes)
       end
     end
 
     def upsert(id, **attributes)
       attributes = super
       @type.new(attributes).validate!
-      @type.upsert({ id: identify(id), **attributes })
+      @type.upsert({ id: id.hash, **attributes })
     end
-
-    private def identify(id) = ::ActiveRecord::FixtureSet.identify(id, @type.type_for_attribute(@type.primary_key).type)
   end
 
   module Data

--- a/test/fixtures/yaml_records.yml
+++ b/test/fixtures/yaml_records.yml
@@ -1,3 +1,0 @@
-first:
-  name: "YAML"
-  account: business

--- a/test/oaken_test.rb
+++ b/test/oaken_test.rb
@@ -24,11 +24,6 @@ class OakenTest < Oaken::Test
     end
   end
 
-  def test_fixture_yml_compatibility
-    assert_equal "YAML", YamlRecord.first.name
-    assert_equal accounts.business, YamlRecord.first.account
-  end
-
   def test_accessing_fixture
     assert_equal "Kasper", users.kasper.name
     assert_equal "Coworker", users.coworker.name

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,11 +58,6 @@ ActiveRecord::Schema.define do
     t.integer :price_cents, null: false
     t.timestamps
   end
-
-  create_table :yaml_records, force: true do |t|
-    t.integer :account_id, null: false
-    t.string :name, null: false
-  end
 end
 
 class Account < ActiveRecord::Base


### PR DESCRIPTION
With the progress we've made via the top-level model grouping I don't think we need to have this backwards compatibility.