### PR TITLE
Introduce a pattern for demo data

### DIFF
--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -5,8 +5,8 @@ module Oaken::Seeds
     Oaken.inflector.classify(name).safe_constantize || super
   end
 
-  def self.method_missing(name, ...)
-    name = name.to_s
+  def self.method_missing(meth, ...)
+    name = meth.to_s
     if type = Oaken.inflector.classify(name).safe_constantize
       register type, name
       public_send(name, ...)

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -4,3 +4,9 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+namespace "db:seed" do
+  task demo: :environment do
+    Oaken::Seeds.seed "accounts/demo"
+  end
+end

--- a/test/dummy/db/seeds/accounts/demo.rb
+++ b/test/dummy/db/seeds/accounts/demo.rb
@@ -1,0 +1,1 @@
+accounts.create :demo, name: "Demonstrable Co."


### PR DESCRIPTION
Introduce db:seed:demo in apps, and have that load db/seeds/accounts/demo.rb.

We'll write this up in the README at some point. There's probably tons of stuff, I haven't thought about here. So I'm trying to introduce and then start seeing where it breaks.

This means that users can eventually run and re-run `db:seed:demo` in production to have marketing accounts they can use for screenshots.