### PR TITLE
Make Oaken somewhat self-corrective

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -44,6 +44,8 @@ module Oaken
         @entry = entry
         @entry.load_onto seeds
       end
+
+      @entry = nil
     end
   end
 

--- a/lib/oaken/entry.rb
+++ b/lib/oaken/entry.rb
@@ -20,6 +20,10 @@ class Oaken::Entry < DelegateClass(PStore)
     super PStore.new(prepared_store_path)
   end
 
+  def remove
+    path.unlink if path.exist?
+  end
+
   def load_onto(seeds)
     transaction do
       if replay?

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -2,7 +2,18 @@ class Oaken::Stored::ActiveRecord < Struct.new(:type, :key)
   def initialize(type, key = nil)
     super(type, key || Oaken.inflector.tableize(type.name))
   end
-  delegate :find, :insert_all, to: :type
+  delegate :insert_all, to: :type
+
+  def find(...)
+    type.find(...)
+  rescue ActiveRecord::RecordNotFound
+    # When a database's data has changed without touching any Oaken seed, Oaken thinks
+    # its cache is still valid, as no checksums have changed, however the underlying data is no longer there.
+    # The `find` call raises in that case and we can remove the cache for that seed file.
+    location = caller_locations(2, 1).first
+    Oaken::Entry.new(Pathname(location.path)).remove
+    raise "Database data changed without Oaken knowing: missing record originally created on #{location}. Oaken has reset the file's cache, try rerunning the command."
+  end
 
   def create(reader = nil, **attributes)
     lineno = caller_locations(1, 1).first.lineno


### PR DESCRIPTION
If we run the drop, create, migrate below the database has changed while Oaken still believes the data is in the db and it's safe to replay the file when it's not.

The `find` will raise in that case and we can try to reset the file cache, so users can just rerun the command.

Test with:

```sh
RAILS_ENV=test bin/rails db:drop db:create db:migrate
bin/rails test
```

TODO: Hook into db:drop and reset our replay cache.