### PR TITLE
Split `prepare` out

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Oaken is an alternative to fixtures and/or factories to manage your development,
 You can set it up in `db/seeds.rb`, like this:
 
 ```ruby
-Oaken.seeds do
+Oaken.prepare do
   seed :accounts, :data
 end
 ```

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -47,15 +47,17 @@ module Oaken
     end
   end
 
-  def self.seeds(&block)
+  def self.prepare(&block)
     store_path.rmtree if ENV["OAKEN_RESET"]
+    Seeds.instance_eval(&block)
+    Seeds
+  end
 
-    if block_given?
-      Seeds.instance_eval(&block)
-    else
+  def self.seeds
+    unless defined?(@loaded)
+      @loaded = true
       Rails.application.load_seed
     end
-
     Seeds
   end
 end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,4 +1,4 @@
-Oaken.seeds do
+Oaken.prepare do
   register Menu::Item
 
   seed :accounts, :data


### PR DESCRIPTION
Having `seeds do` with `seed` in there seems confusing, so let's split these two methods into their constituent parts.