### PR TITLE
Wrap each seed file load in a transaction

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -47,6 +47,10 @@ module Oaken
     end
   end
 
+  def self.transaction(&block)
+    ActiveRecord::Base.transaction(&block)
+  end
+
   def self.prepare(&block)
     store_path.rmtree if ENV["OAKEN_RESET"]
     Seeds.instance_eval(&block)

--- a/lib/oaken/entry.rb
+++ b/lib/oaken/entry.rb
@@ -34,6 +34,12 @@ class Oaken::Entry < DelegateClass(PStore)
     end
   end
 
+  def transaction(&block)
+    super do
+      Oaken.transaction(&block)
+    end
+  end
+
   def replay?
     checksum == @computed_checksum
   end

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -2,6 +2,7 @@ class Oaken::Stored::ActiveRecord < Struct.new(:type, :key)
   def initialize(type, key = nil)
     super(type, key || Oaken.inflector.tableize(type.name))
   end
+  delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
   delegate :find, :insert_all, to: :type
 
   def create(reader = nil, **attributes)


### PR DESCRIPTION
Prevents partially applied data from being stuck in the database.

I'm still not sure what changes we'd need for multi-db setups. For now I've added a `transaction` delegation, so users can do:

```ruby
users.create name: "Something"

table_on_secondary_database.transaction do
  table_on_secondary_database.create name: "Something"
end
```