### PR TITLE
Bring back default attributes

### DIFF
--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -1,12 +1,21 @@
 class Oaken::Stored::ActiveRecord < Struct.new(:type, :key)
   def initialize(type, key = nil)
     super(type, key || Oaken.inflector.tableize(type.name))
+    @attributes = {}
   end
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
-  delegate :find, :insert_all, to: :type
+  delegate :find, :insert_all, :pluck, to: :type
+
+  def defaults(**attributes)
+    @attributes = @attributes.merge(attributes)
+    @attributes
+  end
 
   def create(reader = nil, **attributes)
     lineno = caller_locations(1, 1).first.lineno
+
+    attributes = @attributes.merge(attributes)
+    attributes.transform_values! { _1.respond_to?(:call) ? _1.call : _1 }
 
     type.create!(**attributes).tap do |record|
       define_reader reader, record.id, lineno if reader
@@ -15,6 +24,9 @@ class Oaken::Stored::ActiveRecord < Struct.new(:type, :key)
 
   def insert(reader = nil, **attributes)
     lineno = caller_locations(1, 1).first.lineno
+
+    attributes = @attributes.merge(attributes)
+    attributes.transform_values! { _1.respond_to?(:call) ? _1.call : _1 }
 
     type.new(attributes).validate!
     type.insert(attributes).tap do

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,5 +1,8 @@
 Oaken.prepare do
   register Menu::Item
 
+  user_counter = 0
+  users.defaults name: -> { "Customer #{user_counter += 1}" }
+
   seed :accounts, :data
 end

--- a/test/dummy/db/seeds/accounts/kaspers_donuts.rb
+++ b/test/dummy/db/seeds/accounts/kaspers_donuts.rb
@@ -11,4 +11,4 @@ supporter = users.create name: "Super Supporter"
 orders.insert_all [user_id: supporter.id, item_id: plain_donut.id] * 10
 
 orders.insert_all \
-  10.times.map { { user_id: users.create(name: "Customer #{_1}").id, item_id: menu.items.sample.id } }
+  10.times.map { { user_id: users.create.id, item_id: menu.items.sample.id } }

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -18,6 +18,14 @@ class OakenTest < ActiveSupport::TestCase
     assert plans.test_premium
   end
 
+  test "default attributes" do
+    names = users.pluck(:name)
+
+    (1..10).each do
+      assert_includes names, "Customer #{_1}"
+    end
+  end
+
   test "source attribution" do
     donuts_location, kasper_location = [accounts.method(:kaspers_donuts), users.method(:kasper)].map(&:source_location)
     assert_match "db/seeds/accounts/kaspers_donuts.rb", donuts_location.first


### PR DESCRIPTION
Now that we've got db/seeds.rb as the setup place, it seems like a fit to add default attributes in there.

Note: I'm starting to really like calling methods on our collection instead of the class name. Like `users.pluck(:name)` instead of `User.pluck(:name)`. Not sure why, but I'll add an extra delegation for now.