### PR TITLE
Reset Oaken when running tasks that change database data

### DIFF
--- a/lib/oaken/railtie.rb
+++ b/lib/oaken/railtie.rb
@@ -3,4 +3,23 @@ class Oaken::Railtie < Rails::Railtie
     Oaken.lookup_paths << "db/seeds/#{Rails.env}"
     Oaken.store_path = Oaken.store_path.join(Rails.env)
   end
+
+  rake_tasks do
+    namespace :oaken do
+      task("reset")     { Oaken.store_path.rmtree }
+      task("reset:all") { Oaken.store_path.dirname.rmtree }
+
+      task "reset:include_test" do
+        # Some db: tasks in development also manipulate the test database.
+        Oaken.store_path.sub("development", "test").rmtree if Rails.env.development?
+      end
+    end
+
+    task "db:drop"      => ["oaken:reset", "oaken:reset:include_test"]
+    task "db:purge"     => ["oaken:reset", "oaken:reset:include_test"]
+    task "db:purge:all" => ["oaken:reset:all"]
+
+    # db:seed:replant runs trunacte_all, after trial-and-error we need to hook into that and not the replant task.
+    task "db:truncate_all" => "oaken:purge"
+  end
 end


### PR DESCRIPTION
Running tasks like db:drop and db:reset will wipe out the database data, but Oaken will still think it needs to replay its seed files. So we hook into these sorts of tasks and reset Oaken automatically.

Additionally, tasks like db:drop automatically drops the test database when run in development. We account for that too and also reset Oaken's test env data.