### PR TITLE
Fix class level loading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,3 @@ jobs:
     - name: Uncached tests
       run: bin/rails test
       working-directory: test/dummy
-      env:
-        OAKEN_RESET: "1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         bundler-cache: true
 
     - name: Uncached tests
-      run: bin/rails test
+      run: OAKEN_RESET=1 bin/rails test
       working-directory: test/dummy
 
     - name: Cached tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,7 @@ jobs:
         bundler-cache: true
 
     - name: Uncached tests
-      run: OAKEN_RESET=1 bin/rails test
-      working-directory: test/dummy
-
-    - name: Cached tests
       run: bin/rails test
       working-directory: test/dummy
+      env:
+        OAKEN_RESET: "1"

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -59,5 +59,8 @@ module Oaken::Seeds
   #       seed "cases/pagination" # Loads `db/seeds/{,test}/cases/pagination{,**/*}.rb`
   #     end
   #   end
-  delegate :seed, to: Oaken::Seeds
+  def seed(...)
+    Oaken.store_path.rmtree # TODO: Remove after we yank the store stuff.
+    Oaken::Seeds.seed(...)
+  end
 end

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -21,10 +21,6 @@ module Oaken::Seeds
   def self.provider = Oaken::Stored::ActiveRecord
 
   class << self
-    # Expose a class `seed` method for individual test classes to use.
-    # TODO: support parallelization somehow.
-    def included(klass) = klass.singleton_class.delegate(:seed, to: Oaken::Seeds)
-
     # Set up a general seed rule or perform a one-off seed for a test file.
     #
     # You can set up a general seed rule in `db/seeds.rb` like this:
@@ -55,4 +51,13 @@ module Oaken::Seeds
     end
     def entry = @loader.entry
   end
+
+  # Call `seed` in tests to load individual case files:
+  #
+  #   class PaginationTest < ActionDispatch::IntegrationTest
+  #     setup do
+  #       seed "cases/pagination" # Loads `db/seeds/{,test}/cases/pagination{,**/*}.rb`
+  #     end
+  #   end
+  delegate :seed, to: Oaken::Seeds
 end

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -34,8 +34,8 @@ module Oaken::Seeds
     # Say you have `db/seeds/test/cases/pagination.rb`, you can load it like this:
     #
     #   # test/integration/pagination_test.rb
-    #   class PaginationTest < ActionDispatch::TestCase
-    #     seed "cases/pagination"
+    #   class PaginationTest < ActionDispatch::IntegrationTest
+    #     setup { seed "cases/pagination" }
     #   end
     def seed(*directories)
       Oaken.lookup_paths.product(directories).each do |path, directory|

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -25,6 +25,22 @@ module Oaken::Seeds
     # TODO: support parallelization somehow.
     def included(klass) = klass.singleton_class.delegate(:seed, to: Oaken::Seeds)
 
+    # Set up a general seed rule or perform a one-off seed for a test file.
+    #
+    # You can set up a general seed rule in `db/seeds.rb` like this:
+    #
+    #   Oaken.prepare do
+    #     seed :accounts # Seeds from `db/seeds/accounts/**/*.rb` and `db/seeds/<Rails.env>/accounts/**/*.rb`
+    #   end
+    #
+    # Then if you need a test specific scenario, we recommend putting them in `db/seeds/test/cases`.
+    #
+    # Say you have `db/seeds/test/cases/pagination.rb`, you can load it like this:
+    #
+    #   # test/integration/pagination_test.rb
+    #   class PaginationTest < ActionDispatch::TestCase
+    #     seed "cases/pagination"
+    #   end
     def seed(*directories)
       Oaken.lookup_paths.product(directories).each do |path, directory|
         load_from Pathname(path).join(directory.to_s)

--- a/test/dummy/test/integration/pagination_test.rb
+++ b/test/dummy/test/integration/pagination_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class PaginationTest < ActiveSupport::TestCase
-  seed "cases/pagination"
+  setup { seed "cases/pagination" }
 
   test "pagination sorta" do
     assert_operator Order.count, :>=, 100


### PR DESCRIPTION
When doing a `self.class.seed` from within a test, we'd be within the Test Class scope, so the `@loader` variable would assign there and and not on `Oaken::Seeds.loader`.

The old structure was a little muddy anyway, so this attempts a rewrite that's hopefully clearer.

Now we'll always be within `Oaken::Seeds`' `singleton_class`.

Note: originally the point about injecting `load_onto Oaken::Seeds` was so you could potentially have other seeds modules, so you could have your app seeds split up ala Packwerk. But it doesn't really work and it's kinda unclear how I'd make it work, so it's probably better to yank it in a bit.

cc @tcannonfodder