### PR TITLE
Add decorative `section` method.

### DIFF
--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -49,6 +49,29 @@ module Oaken::Seeds
     ensure
       @loader = nil
     end
+
+    # `section` is purely for decorative purposes to carve up `Oaken.prepare` and seed files.
+    #
+    #   Oaken.prepare do
+    #     section :roots # Just the very few top-level models like Accounts and Users.
+    #     users.defaults email_address: -> { Faker::Internet.email }, webauthn_id: -> { SecureRandom.hex }
+    #
+    #     section :stems # Models building on the roots.
+    #
+    #     section :leafs # Remaining models, bulk of them, hanging off root and stem models.
+    #
+    #     section do
+    #       seed :accounts, :data
+    #     end
+    #   end
+    #
+    # Since `section` is defined as `def section(*, **) = yield if block_given?`, you can use
+    # all of Ruby's method signature flexibility to help communicate structure better.
+    #
+    # Use positional and keyword arguments, or use blocks to indent them, or combine them all.
+    def section(*, **)
+      yield if block_given?
+    end
   end
 
   # Call `seed` in tests to load individual case files:

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,8 +1,15 @@
 Oaken.prepare do
+  section :registrations
   register Menu::Item
 
+  section :roots
   user_counter = 0
   users.defaults name: -> { "Customer #{user_counter += 1}" }
 
-  seed :accounts, :data
+  section :stems
+  section :leafs
+
+  section do
+    seed :accounts, :data
+  end
 end

--- a/test/dummy/db/seeds/accounts/kaspers_donuts.rb
+++ b/test/dummy/db/seeds/accounts/kaspers_donuts.rb
@@ -1,12 +1,16 @@
+section :accounts
 donuts = accounts.create :kaspers_donuts, name: "Kasper's Donuts"
 
+section :users
 kasper   = users.create :kasper,   name: "Kasper",   accounts: [donuts]
 coworker = users.create :coworker, name: "Coworker", accounts: [donuts]
 
+section :menus, :with_items
 menu = menus.create account: donuts
 plain_donut     = menu_items.create menu: menu, name: "Plain",     price_cents: 10_00
 sprinkled_donut = menu_items.create menu: menu, name: "Sprinkled", price_cents: 10_10
 
+section :orders
 supporter = users.create name: "Super Supporter"
 orders.insert_all [user_id: supporter.id, item_id: plain_donut.id] * 10
 


### PR DESCRIPTION
Sometimes people try to sub-divide a file with comments to connote sections, but my eye always end up skipping those. And you can't nest them with more indentation.

Instead we can add a decorative method to help us — and we can use blocks to help indent certain sections.