### PR TITLE
Add basic RSpec support

### DIFF
--- a/lib/oaken/rspec_setup.rb
+++ b/lib/oaken/rspec_setup.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.include(Oaken::Seeds)
+
+  config.use_transactional_fixtures = true
+
+  config.before(:suite) do
+    # Mimic fixtures by truncating before inserting.
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    Oaken.load_seed
+  end
+end


### PR DESCRIPTION
Not sure of the whole setup. This is mostly copied from `test_setup.rb` but without the parallelization (🥲)

```ruby
# in spec/rails_helper.rb
require "oaken/rspec_setup"
```