### PR TITLE
remove non-needed name arg

### DIFF
--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -8,15 +8,15 @@ module Oaken::Seeds
   def self.method_missing(meth, ...)
     name = meth.to_s
     if type = name.classify.safe_constantize
-      register type, name
+      register type
       public_send(name, ...)
     else
       super
     end
   end
 
-  def self.register(type, key = nil)
-    stored = provider.new(type, key) and define_method(stored.key) { stored }
+  def self.register(type)
+    stored = provider.new(type) and define_method(stored.key) { stored }
   end
   def self.provider = Oaken::Stored::ActiveRecord
 

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -1,6 +1,6 @@
 class Oaken::Stored::ActiveRecord < Struct.new(:type, :key)
-  def initialize(type, key = nil)
-    super(type, key || type.table_name)
+  def initialize(type)
+    super(type, type.table_name)
     @attributes = {}
   end
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.


### PR DESCRIPTION
Since we added use ActiveRecord#table_name in https://github.com/kaspth/oaken/pull/78, no need to be able to pass a custom key here