### PR TITLE
Yank SQL file loading

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -18,17 +18,12 @@ module Oaken
 
   class Loader
     def initialize(path)
-      @entries = Pathname.glob("#{path}{,/**/*}.{rb,sql}").sort
+      @entries = Pathname.glob("#{path}{,/**/*}.rb").sort
     end
 
-    def load_onto(seeds)
-      @entries.each do |path|
-        ActiveRecord::Base.transaction do
-          case path.extname
-          when ".rb"  then seeds.class_eval path.read, path.to_s
-          when ".sql" then ActiveRecord::Base.connection.execute path.read
-          end
-        end
+    def load_onto(seeds) = @entries.each do |path|
+      ActiveRecord::Base.transaction do
+        seeds.class_eval path.read, path.to_s
       end
     end
   end

--- a/test/dummy/db/seeds/test/cases/pagination.sql
+++ b/test/dummy/db/seeds/test/cases/pagination.sql
@@ -1,1 +1,0 @@
-INSERT INTO users (name, email_address, created_at, updated_at) VALUES ('pagination.sql', 'pagination@example.com', TIME('NOW'), TIME('NOW'))

--- a/test/dummy/test/integration/pagination_test.rb
+++ b/test/dummy/test/integration/pagination_test.rb
@@ -6,8 +6,4 @@ class PaginationTest < ActiveSupport::TestCase
   test "pagination sorta" do
     assert_operator Order.count, :>=, 100
   end
-
-  test "pagination loading from sql case" do
-    assert User.find_by(name: "pagination.sql")
-  end
 end


### PR DESCRIPTION
If you need to test something like Marshal parsing between different Ruby/Rails versions, it's pretty easy to insert your SQL dump directly into your test case, like so:

```ruby
setup do
  ActiveRecord::Base.connection.execute <<~SQL
    INSERT INTO users (name, email_address, created_at, updated_at) VALUES ('pagination.sql', 'pagination@example.com', TIME('NOW'), TIME('NOW'))
  SQL
end
```

If the SQL is too long, users can use `file_fixture("sqls/pagination.sql").read` or similar to set it up.

I don't think Oaken needs to ship a more complex wrapper around this.

@tcannonfodder you originally requested this, what do you think?