### PR TITLE
Auto-register namespaces

### DIFF
--- a/test/dummy/app/models/menu/item/detail.rb
+++ b/test/dummy/app/models/menu/item/detail.rb
@@ -1,0 +1,3 @@
+class Menu::Item::Detail < ApplicationRecord
+  belongs_to :menu_item, class_name: "Menu::Item"
+end

--- a/test/dummy/db/migrate/20240630172609_create_menu_item_details.rb
+++ b/test/dummy/db/migrate/20240630172609_create_menu_item_details.rb
@@ -1,0 +1,10 @@
+class CreateMenuItemDetails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :menu_item_details do |t|
+      t.references :menu_item, null: false, foreign_key: true
+      t.text :description,     null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_17_160024) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_172609) do
   create_table "accounts", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -24,6 +24,14 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_17_160024) do
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_administratorships_on_account_id"
     t.index ["user_id"], name: "index_administratorships_on_user_id"
+  end
+
+  create_table "menu_item_details", force: :cascade do |t|
+    t.integer "menu_item_id", null: false
+    t.text "description", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_item_id"], name: "index_menu_item_details_on_menu_item_id"
   end
 
   create_table "menu_items", force: :cascade do |t|
@@ -69,6 +77,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_17_160024) do
 
   add_foreign_key "administratorships", "accounts"
   add_foreign_key "administratorships", "users"
+  add_foreign_key "menu_item_details", "menu_items"
   add_foreign_key "menu_items", "menus"
   add_foreign_key "menus", "accounts"
   add_foreign_key "orders", "menu_items", column: "item_id"

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,9 +1,6 @@
 Oaken.prepare do
   defaults name: -> { "Shouldn't be used for users.name" }, title: -> { "Global Default Title" }
 
-  section :registrations
-  register Menu::Item
-
   section :roots
   user_counter, email_address_counter = 0, 0
   users.defaults name: -> { "Customer #{user_counter += 1}" },

--- a/test/dummy/db/seeds/accounts/kaspers_donuts.rb
+++ b/test/dummy/db/seeds/accounts/kaspers_donuts.rb
@@ -11,6 +11,8 @@ plain_donut     = menu_items.create menu: menu, name: "Plain",     price_cents: 
 sprinkled_donut = menu_items.create menu: menu, name: "Sprinkled", price_cents: 10_10
 menus.label basic: menu
 
+menu_item_details.create :plain, menu_item: plain_donut, description: "Plain, but mighty."
+
 section :orders
 supporter = users.create name: "Super Supporter"
 orders.insert_all [user_id: supporter.id, item_id: plain_donut.id] * 10

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -22,6 +22,17 @@ class OakenTest < ActiveSupport::TestCase
     assert menus.basic
   end
 
+  test "auto-registering" do
+    assert_respond_to self, :menu_items
+    assert_respond_to self, :menu_item_details
+
+    menu_item_details.plain.tap do |detail|
+      assert_equal "Plain", detail.menu_item.name
+      assert_equal "Plain, but mighty.", detail.description
+      assert_kind_of Menu::Item::Detail, detail
+    end
+  end
+
   test "global attributes" do
     plan = plans.upsert price_cents: 10_00
 

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -22,7 +22,7 @@ class OakenTest < ActiveSupport::TestCase
     assert menus.basic
   end
 
-  test "auto-registering" do
+  test "auto-registering with full namespaces" do
     assert_respond_to self, :menu_items
     assert_respond_to self, :menu_item_details
 
@@ -31,6 +31,15 @@ class OakenTest < ActiveSupport::TestCase
       assert_equal "Plain, but mighty.", detail.description
       assert_kind_of Menu::Item::Detail, detail
     end
+  end
+
+  test "auto-registering with partial namespaces" do
+    Menu::HiddenDiscount = Class.new do
+      def self.table_name   = "menu_hidden_discounts"
+      def self.column_names = []
+    end
+
+    assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_hidden_discounts
   end
 
   test "global attributes" do


### PR DESCRIPTION
Oaken now auto-registers namespaced models as well.

So in addition to `accounts` => `Account`, we can also auto-register partial and fully nested namespaces, in this order:

```
account_jobs => AccountJob | Account::Job
account_job_tasks => AccountJobTask | Account::JobTask | Account::Job::Task
```

If you have classes that don't follow this naming convention, you must call `register` manually.