### PR TITLE
guard against nil key and @referenced

### DIFF
--- a/lib/generators/oaken/convert/fixtures_generator.rb
+++ b/lib/generators/oaken/convert/fixtures_generator.rb
@@ -50,7 +50,7 @@ class Oaken::Convert::Fixture
       when Array then input.map { recursive_convert _1 }.join(", ")
       when Integer then input
       else
-        if key == @referenced&.first
+        if key && key == @referenced&.first
           @referenced.last == :plural ? "[#{input}]" : input
         else
           "\"#{input}\""


### PR DESCRIPTION
if `key` and `@referenced` are both nil, we will try to access @referenced.last and explode like this:

```
oaken-0.7.0/lib/generators/oaken/convert/fixtures_generator.rb:54:in `recursive_convert': undefined method `last' for nil (NoMethodError)

          @referenced.last == :plural ? "[#{input}]" : input
```

this patch resolved the issue and allowed me to run the generator successfully.