### PR TITLE
Allow any class in fixture YAML

### DIFF
--- a/lib/generators/oaken/convert/fixtures_generator.rb
+++ b/lib/generators/oaken/convert/fixtures_generator.rb
@@ -75,7 +75,7 @@ class Oaken::Convert::FixturesGenerator < Rails::Generators::Base
   def parse
     @fixtures = Dir.glob("test/fixtures/**/*.yml").to_h do |path|
       model_name = path.delete_prefix("test/fixtures/").chomp(".yml")
-      [model_name, YAML.load_file(path).presence&.map { Oaken::Convert::Fixture.new(model_name, _1, _2) }]
+      [model_name, YAML.unsafe_load_file(path).presence&.map { Oaken::Convert::Fixture.new(model_name, _1, _2) }]
     rescue Psych::SyntaxError
       say "Skipped #{path} due to ERB content or other YAML parsing issues.", :yellow
     end.tap(&:compact_blank!)


### PR DESCRIPTION
When loading existing fixtures, it's possible to hit a ruby object class that is not allowed by the (new) Psych default of `load_file` meaning `safe_load_file`. In my particular case, I got an exception because my fixtures included a Time object.

This patch resolved the issue and allowed me to convert my fixtures successfully. Since we are only loading local fixture files exclusively, it should be fine to use Psych's unsafe load.

Here's the backtrace for the error I observed that was fixed by this patch:

```
psych-5.2.1/lib/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Time (Psych::DisallowedClass)
        from psych-5.2.1/lib/psych/class_loader.rb:28:in `load'
        from psych-5.2.1/lib/psych/scalar_scanner.rb:115:in `parse_time'
        from psych-5.2.1/lib/psych/scalar_scanner.rb:59:in `tokenize'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:65:in `deserialize'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:129:in `visit_Psych_Nodes_Scalar'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:30:in `visit'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:6:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:346:in `block in revive_hash'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `each'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `each_slice'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `revive_hash'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:168:in `visit_Psych_Nodes_Mapping'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:30:in `visit'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:6:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:346:in `block in revive_hash'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `each'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `each_slice'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:344:in `revive_hash'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:168:in `visit_Psych_Nodes_Mapping'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:30:in `visit'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:6:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:319:in `visit_Psych_Nodes_Document'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:30:in `visit'
        from psych-5.2.1/lib/psych/visitors/visitor.rb:6:in `accept'
        from psych-5.2.1/lib/psych/visitors/to_ruby.rb:35:in `accept'
        from psych-5.2.1/lib/psych.rb:336:in `safe_load'
        from psych-5.2.1/lib/psych.rb:371:in `load'
        from bootsnap-1.18.4/lib/bootsnap/compile_cache/yaml.rb:217:in `input_to_output'
        from bootsnap-1.18.4/lib/bootsnap/compile_cache/yaml.rb:232:in `fetch'
        from bootsnap-1.18.4/lib/bootsnap/compile_cache/yaml.rb:232:in `load_file'
        from oaken-0.7.0/lib/generators/oaken/convert/fixtures_generator.rb:78:in `block in parse'
```