### PR TITLE
More robust location definitions

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -39,6 +39,12 @@ module Oaken
         seeds.class_eval path.read, path.to_s
       end
     end
+
+    def self.definition_location
+      # Trickery abounds! Due to Ruby's `caller_locations` + our `load_onto`'s `class_eval` above
+      # we can use this format to detect the location in the seed file where the call came from.
+      caller_locations(2, 8).find { _1.label.match? /block .*?in load_onto/ }
+    end
   end
 
   def self.prepare(&block) = Seeds.instance_eval(&block)

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -43,7 +43,7 @@ module Oaken
     def self.definition_location
       # Trickery abounds! Due to Ruby's `caller_locations` + our `load_onto`'s `class_eval` above
       # we can use this format to detect the location in the seed file where the call came from.
-      caller_locations(2, 8).find { _1.label.match? /block .*?in load_onto/ }
+      caller_locations(2, 8).find { _1.label.match? /block .*?load_onto/ }
     end
   end
 

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -49,7 +49,7 @@ class Oaken::Stored::ActiveRecord
   #
   # Note: `users.method(:someone).source_location` also points back to the file and line of the `label` call.
   def label(**labels)
-    labels.transform_values(&:id).each { _label _1, _2 }
+    labels.each { |label, record| _label label, record.id }
   end
 
   private def _label(name, id)

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -49,11 +49,13 @@ class Oaken::Stored::ActiveRecord
   #
   # Note: `users.method(:someone).source_location` also points back to the file and line of the `label` call.
   def label(**labels)
-    # TODO: Fix hardcoding of db/seeds instead of using Oaken.lookup_paths
-    location = caller_locations(1, 6).find { _1.path.match? /db\/seeds\// }
+    labels.transform_values(&:id).each { _label _1, _2 }
+  end
 
-    labels.each do |label, record|
-      class_eval "def #{label} = find(#{record.id.inspect})", location.path, location.lineno
-    end
+  private def _label(name, id)
+    raise ArgumentError, "you can only define labelled records outside of tests" \
+      unless location = Oaken::Loader.definition_location
+
+    class_eval "def #{name} = find(#{id.inspect})", location.path, location.lineno
   end
 end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -76,6 +76,12 @@ class OakenTest < ActiveSupport::TestCase
     assert_match "db/seeds/test/data/users.rb", users.method(:test_user).source_location.first
   end
 
+  test "can't use labels within tests" do
+    assert_raise ArgumentError do
+      users.label kasper_2: users.kasper
+    end
+  end
+
   test "updating fixture" do
     users.kasper.update name: "Kasper2"
     assert_equal "Kasper2", users.kasper.name


### PR DESCRIPTION
Say you had this Oaken seed file:

```ruby
users.create :kasper, name: "Kasper"
```

We want `users.method(:kasper)` to point back to that file and line to help debugging.

However, we had a hardcoded db/seeds in our detection, which meant that create/upsert/label in tests would fail on a NoMehodError because our `find` wouldn't return anything.

In tests, labels make less sense in general, so I'm thinking we should allow those.

I'm also thinking I should try to more sharply define the preparation phase versus the running phase.

The preparation phase: loading and executing db/seeds.rb, setup defaults, helpers and common records
The running phase: when running tests, you shouldn't mutate anything really, and labels shouldn't suddenly spring up, generally things should be deterministic.

`Oaken.preparing?`/`Oaken.running?` may be on the table too. Note: this does get complicated if people are using `seed "cases/pagination"` with one-off seeds. Hm.

Anyway, I'm detecting the path via a quirk on the label + our loading so we don't need to use `lookup_paths` at all. I'm not sure I'm liking any of this.