### PR TITLE
Document `label` method.

### DIFF
--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -34,6 +34,20 @@ class Oaken::Stored::ActiveRecord
     record
   end
 
+  # Expose a record instance that's setup outside of using `create`/`upsert`. Like this:
+  #
+  #   users.label someone: User.create!(name: "Someone")
+  #   users.label someone: FactoryBot.create(:user, name: "Someone")
+  #
+  # Now `users.someone` returns the record instance.
+  #
+  # Ruby's Hash argument forwarding also works:
+  #
+  #   someone = users.create(name: "Someone")
+  #   someone_else = users.create(name: "Someone Else")
+  #   users.label someone:, someone_else:
+  #
+  # Note: `users.method(:someone).source_location` also points back to the file and line of the `label` call.
   def label(**labels)
     # TODO: Fix hardcoding of db/seeds instead of using Oaken.lookup_paths
     location = caller_locations(1, 6).find { _1.path.match? /db\/seeds\// }

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -66,7 +66,10 @@ class OakenTest < ActiveSupport::TestCase
     assert_match "db/seeds/accounts/kaspers_donuts.rb", kasper_location.first
     assert_operator donuts_location.second, :<, kasper_location.second
 
-    assert_match "db/seeds/accounts/kaspers_donuts.rb", menus.method(:basic).source_location.first
+    administratorship_location, basic_location = [administratorships.method(:kasper_administratorship), menus.method(:basic)].map(&:source_location)
+    assert_match "db/seeds/accounts/kaspers_donuts.rb", administratorship_location.first
+    assert_match "db/seeds/accounts/kaspers_donuts.rb", basic_location.first
+    assert_operator administratorship_location.second, :<, basic_location.second
 
     assert_match "db/seeds/data/plans.rb",      plans.method(:basic).source_location.first
     assert_match "db/seeds/test/data/plans.rb", plans.method(:test_premium).source_location.first


### PR DESCRIPTION
Ref #94.

So it's a little clearer that it is supported API.

Also test the source locations of the direct `label`-calls more.