### PR TITLE
Document loading one-off cases in RSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ class PaginationTest < ActionDispatch::IntegrationTest
 end
 ```
 
+And in RSpec:
+
+```ruby
+RSpec.describe "Pagination", type: :feature do
+  before { seed "cases/pagination" }
+end
+```
+
 > [!NOTE]
 > We're recommending having one-off seeds on an individual unit of work to help reinforce test isolation. Having some seed files be isolated also helps:
 >


### PR DESCRIPTION
Ref https://github.com/kaspth/oaken/issues/95

Needs a `type: :feature` too to match the integration example above.