### PR TITLE
Raise when `seed` finds no files.

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -16,15 +16,40 @@ module Oaken
   singleton_class.attr_reader :lookup_paths
   @lookup_paths = ["db/seeds"]
 
+  def self.lookups_from(paths)
+    lookup_paths.product(paths).map(&File.method(:join))
+  end
+
+  class NoSeedsFoundError < ArgumentError; end
+
   class Loader
-    def initialize(path)
-      @entries = Pathname.glob("#{path}{,/**/*}.rb").sort
+    def self.from(paths)
+      new Path.expand(paths).sort
     end
 
-    def load_onto(seeds) = @entries.each do |path|
+    def initialize(paths)
+      @paths = paths
+    end
+
+    def load_onto(seeds) = @paths.each do |path|
       ActiveRecord::Base.transaction do
         seeds.class_eval path.read, path.to_s
       end
+    end
+
+    class Path
+      def self.expand(paths)
+        patterns = Oaken.lookups_from(paths).map { new _1 }
+        patterns.flat_map(&:to_a).tap do |found|
+          raise Oaken::NoSeedsFoundError, "found no seed files for #{paths.map(&:inspect).join(", ")} when searching with #{patterns.join(", ")}" if found.none?
+        end
+      end
+
+      def initialize(path)
+        @pattern = "#{path}{,/**/*}.rb"
+      end
+      def to_s = @pattern
+      def to_a = Pathname.glob(@pattern)
     end
   end
 

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -62,17 +62,8 @@ module Oaken::Seeds
     #   class PaginationTest < ActionDispatch::IntegrationTest
     #     setup { seed "cases/pagination" }
     #   end
-    def seed(*directories)
-      Oaken.lookup_paths.product(directories).each do |path, directory|
-        load_from Pathname(path).join(directory.to_s)
-      end
-    end
-
-    private def load_from(path)
-      @loader = Oaken::Loader.new path
-      @loader.load_onto self
-    ensure
-      @loader = nil
+    def seed(*paths)
+      Oaken::Loader.from(paths.map(&:to_s)).load_onto self
     end
 
     # `section` is purely for decorative purposes to carve up `Oaken.prepare` and seed files.

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -96,4 +96,16 @@ class OakenTest < ActiveSupport::TestCase
     assert mod.respond_to?(:users) # Now respond_to_missing? hits.
     refute mod.respond_to?(:hmhm)
   end
+
+  test "raises when no files found to seed" do
+    assert_raise(Oaken::NoSeedsFoundError) { seed "missing" }.tap do |error|
+      assert_match "db/seeds/missing{", error.message
+      assert_match "db/seeds/test/missing{", error.message
+    end
+
+    assert_raise(Oaken::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
+      assert_match "db/seeds/test/cases/missing{", error.message
+      assert_match "db/seeds/test/test/cases/missing{", error.message
+    end
+  end
 end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -98,14 +98,12 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "raises when no files found to seed" do
-    assert_raise(Oaken::NoSeedsFoundError) { seed "missing" }.tap do |error|
-      assert_match "db/seeds/missing{", error.message
-      assert_match "db/seeds/test/missing{", error.message
+    assert_raise(Oaken::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
+      assert_match %r|found no seed files for "test/cases/missing"|, error.message
     end
 
-    assert_raise(Oaken::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
-      assert_match "db/seeds/test/cases/missing{", error.message
-      assert_match "db/seeds/test/test/cases/missing{", error.message
+    assert_raise(Oaken::NoSeedsFoundError) { seed :first_missing, :second_missing }.tap do |error|
+      assert_match /found no seed files for "first_missing"/, error.message
     end
   end
 end


### PR DESCRIPTION
Ref https://github.com/kaspth/oaken/issues/95

In case users pass a typo'ed name/path to `seed` we won't give them any indication of what's going on.

Running a test fails silently.

Now we raise when we can't find any files.