### PR TITLE
Expand module auto registering

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -18,12 +18,11 @@ module Oaken
 
     def locate
       starting_type = Object
-      refine_from(starting_type:, &:const_get?).then.detect { _1 != starting_type }
+      refine_from(starting_type:) { _1.const_get(_2) if _1.const_defined?(_2) }
+        .then.find { _1 != starting_type }
     end
 
     private
-      using Module.new { refine(Module) { def const_get?(name); const_get(name) if const_defined?(name); end } }
-
       def refine_from(starting_type:)
         name = +""
         parts.inject(starting_type) do |type, part|

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -7,26 +7,11 @@ module Oaken
   class Error < StandardError; end
 
   autoload :Seeds,     "oaken/seeds"
+  autoload :Type,      "oaken/type"
   autoload :TestSetup, "oaken/test_setup"
 
   module Stored
     autoload :ActiveRecord, "oaken/stored/active_record"
-  end
-
-  class Type < Data.define(:splice)
-    def self.for(name) = new(name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
-
-    def locate
-      possible_consts.filter_map(&:safe_constantize).first
-    end
-
-    private
-      def possible_consts
-        separator_matrix.map { |group| splice.with_index { |_, index| group[index] } }
-      end
-      def separator_matrix = Enumerator.product(*grouped_separators * splice.count).lazy
-
-      grouped_separators = [["::", ""]] and define_method(:grouped_separators) { grouped_separators }
   end
 
   singleton_class.attr_reader :lookup_paths

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -21,12 +21,12 @@ module Oaken
     end
 
     private
-      GROUPED_SEPARATORS = [["::", ""]]
-
       def possible_consts
-        separator_matrix.lazy.map { |parts| splice.with_index { parts[_2] } }
+        separator_matrix.map { |group| splice.with_index { |_, index| group[index] } }
       end
-      def separator_matrix = (GROUPED_SEPARATORS * splice.count.clamp(1..)).then { |it, *rest| it.product(*rest) }
+      def separator_matrix = Enumerator.product(*grouped_separators * splice.count).lazy
+
+      grouped_separators = [["::", ""]] and define_method(:grouped_separators) { grouped_separators }
   end
 
   singleton_class.attr_reader :lookup_paths

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -13,6 +13,26 @@ module Oaken
     autoload :ActiveRecord, "oaken/stored/active_record"
   end
 
+  class Type < Data.define(:parts)
+    def self.for(name) = new(name.classify.split(/(?=[A-Z])/))
+
+    def locate
+      starting_type = Object
+      refine_from(starting_type:, &:const_get?).then.detect { _1 != starting_type }
+    end
+
+    private
+      using Module.new { refine(Module) { def const_get?(name); const_get(name) if const_defined?(name); end } }
+
+      def refine_from(starting_type:)
+        name = +""
+        parts.inject(starting_type) do |type, part|
+          name << part
+          yield(type, name)&.tap { name.clear } || type
+        end
+      end
+  end
+
   singleton_class.attr_reader :lookup_paths
   @lookup_paths = ["db/seeds"]
 

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -26,7 +26,7 @@ module Oaken::Seeds
       super
     end
   end
-  def self.respond_to_missing?(name, ...) = Oaken::Type.for(name.to_s).locate || super
+  def self.respond_to_missing?(meth, ...) = Oaken::Type.for(meth.to_s).locate || super
 
   # Register a model class to be accessible as an instance method via `include Oaken::Seeds`.
   # Note: Oaken's auto-register via `method_missing` means it's less likely you need to call this manually.

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -11,25 +11,22 @@ module Oaken::Seeds
   # So when you first call e.g. `accounts.create`, we'll hit `method_missing` here
   # and automatically call `register Account`.
   #
-  # We'll also match partial and full nested namespaces like in this order:
+  # We'll also match partial and full nested namespaces:
   #
   #   accounts => Account
-  #   account_jobs => AccountJob | Account::Job
-  #   account_job_tasks => AccountJobTask | Account::JobTask | Account::Job::Task
+  #   account_jobs => Account::Job | AccountJob
+  #   account_job_tasks => Account::JobTask | Account::Job::Task | AccountJob::Task | AccountJobTask
   #
-  # If you have classes that don't follow this naming convention, you must call `register` manually.
+  # If you have classes that don't follow these naming conventions, you must call `register` manually.
   def self.method_missing(meth, ...)
-    name = meth.to_s.classify
-    name = name.sub!(/(?<=[a-z])(?=[A-Z])/, "::") until name.nil? or type = name.safe_constantize
-
-    if type
+    if type = Oaken::Type.for(meth.to_s).locate
       register type
       public_send(meth, ...)
     else
       super
     end
   end
-  def self.respond_to_missing?(name, ...) = name.to_s.classify.safe_constantize || super
+  def self.respond_to_missing?(name, ...) = Oaken::Type.for(name.to_s).locate || super
 
   # Register a model class to be accessible as an instance method via `include Oaken::Seeds`.
   # Note: Oaken's auto-register via `method_missing` means it's less likely you need to call this manually.

--- a/lib/oaken/type.rb
+++ b/lib/oaken/type.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-class Oaken::Type < Data.define(:stitches)
+class Oaken::Type
   def self.for(name) = new(name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
+  def initialize(stitches) = @stitches = stitches
 
   def locate
     possible_consts.filter_map(&:safe_constantize).first
@@ -10,9 +11,9 @@ class Oaken::Type < Data.define(:stitches)
 
   private
     def separator_matrix
-      Enumerator.product(*grouped_separators * stitches.count).lazy
+      Enumerator.product(*grouped_separators * @stitches.count).lazy
     end
-    def stitch_with(separators) = stitches.each { separators.shift }
+    def stitch_with(separators) = @stitches.each { separators.shift }
 
     define_method :grouped_separators, &[["::", ""]].method(:itself)
 end

--- a/lib/oaken/type.rb
+++ b/lib/oaken/type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Oaken::Type < Data.define(:stitches)
+  def self.for(name) = new(name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
+
+  def locate
+    possible_consts.filter_map(&:safe_constantize).first
+  end
+  def possible_consts = separator_matrix.map { stitch_with _1 }
+
+  private
+    def separator_matrix
+      Enumerator.product(*grouped_separators * stitches.count).lazy
+    end
+    def stitch_with(separators) = stitches.each { separators.shift }
+
+    define_method :grouped_separators, &[["::", ""]].method(:itself)
+end

--- a/lib/oaken/type.rb
+++ b/lib/oaken/type.rb
@@ -14,6 +14,13 @@ class Oaken::Type < Struct.new(:name, :gsub)
   end
 
   private
-    separator_matrixes = (0..3).to_h { |size| [size, Enumerator.product(*[["::", ""]].*(size)).lazy] }
+    # TODO: Remove after dropping Ruby 3.1 support
+    if Enumerator.respond_to?(:product)
+      def self.product(...) = Enumerator.product(...)
+    else
+      def self.product(first = nil, *rest) = first&.product(*rest) || [[]]
+    end
+
+    separator_matrixes = (0..3).to_h { |size| [size, product(*[["::", ""]].*(size)).lazy] }
     define_method(:separator_matrixes) { separator_matrixes }
 end

--- a/lib/oaken/type.rb
+++ b/lib/oaken/type.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-class Oaken::Type
-  def self.for(name) = new(name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
-  def initialize(stitches) = @stitches = stitches
+class Oaken::Type < Struct.new(:name, :gsub)
+  def self.for(name) = new(name, name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
 
   def locate
     possible_consts.filter_map(&:safe_constantize).first
   end
-  def possible_consts = separator_matrix.map { stitch_with _1 }
+
+  def possible_consts
+    separator_matrixes.fetch(gsub.count).map { |seps| gsub.with_index { seps[_2] } }
+  rescue KeyError
+    raise ArgumentError, "can't resolve #{name} to an object, please call register manually"
+  end
 
   private
-    def separator_matrix
-      Enumerator.product(*grouped_separators * @stitches.count).lazy
-    end
-    def stitch_with(separators) = @stitches.each { separators.shift }
-
-    define_method :grouped_separators, &[["::", ""]].method(:itself)
+    separator_matrixes = (0..3).to_h { |size| [size, Enumerator.product(*[["::", ""]].*(size)).lazy] }
+    define_method(:separator_matrixes) { separator_matrixes }
 end

--- a/test/dummy/test/models/oaken/type_test.rb
+++ b/test/dummy/test/models/oaken/type_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Oaken::TypeTest < ActiveSupport::TestCase
+  test "with zero segments" do
+    type = Oaken::Type.for("users")
+
+    assert_consts type, ["User"]
+    assert_equal User, type.locate
+  end
+
+  test "with one segment" do
+    type = Oaken::Type.for("menu_items")
+
+    assert_consts type, [
+      "Menu::Item",
+      "MenuItem"
+    ]
+    assert_equal Menu::Item, type.locate
+  end
+
+  test "with two segments" do
+    type = Oaken::Type.for("menu_item_details")
+
+    assert_consts type, [
+      "Menu::Item::Detail",
+      "Menu::ItemDetail",
+      "MenuItem::Detail",
+      "MenuItemDetail"
+    ]
+    assert_equal Menu::Item::Detail, type.locate
+  end
+
+  test "with three segments" do
+    type = Oaken::Type.for("menu_item_detail_segments")
+
+    assert_consts type, [
+      "Menu::Item::Detail::Segment",
+      "Menu::Item::DetailSegment",
+      "Menu::ItemDetail::Segment",
+      "Menu::ItemDetailSegment",
+      "MenuItem::Detail::Segment",
+      "MenuItem::DetailSegment",
+      "MenuItemDetail::Segment",
+      "MenuItemDetailSegment"
+    ]
+    assert_nil type.locate
+  end
+
+  def assert_consts(type, expected)
+    assert_equal expected, type.send(:possible_consts).to_a
+  end
+end

--- a/test/dummy/test/models/oaken/type_test.rb
+++ b/test/dummy/test/models/oaken/type_test.rb
@@ -46,6 +46,13 @@ class Oaken::TypeTest < ActiveSupport::TestCase
     assert_nil type.locate
   end
 
+  test "with four segments" do
+    error = assert_raises ArgumentError do
+      Oaken::Type.for("this_has_four_segments_total").possible_consts.to_a
+    end
+    assert_match /can't resolve this_has_four_segments_total to an object/, error.message
+  end
+
   def assert_consts(type, expected)
     assert_equal expected, type.possible_consts.to_a
   end

--- a/test/dummy/test/models/oaken/type_test.rb
+++ b/test/dummy/test/models/oaken/type_test.rb
@@ -47,6 +47,6 @@ class Oaken::TypeTest < ActiveSupport::TestCase
   end
 
   def assert_consts(type, expected)
-    assert_equal expected, type.send(:possible_consts).to_a
+    assert_equal expected, type.possible_consts.to_a
   end
 end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -1,56 +1,5 @@
 require "test_helper"
 
-class Oaken::TypeTest < ActiveSupport::TestCase
-  test "with zero segments" do
-    type = Oaken::Type.for("users")
-
-    assert_consts type, ["User"]
-    assert_equal User, type.locate
-  end
-
-  test "with one segment" do
-    type = Oaken::Type.for("menu_items")
-
-    assert_consts type, [
-      "Menu::Item",
-      "MenuItem"
-    ]
-    assert_equal Menu::Item, type.locate
-  end
-
-  test "with two segments" do
-    type = Oaken::Type.for("menu_item_details")
-
-    assert_consts type, [
-      "Menu::Item::Detail",
-      "Menu::ItemDetail",
-      "MenuItem::Detail",
-      "MenuItemDetail"
-    ]
-    assert_equal Menu::Item::Detail, type.locate
-  end
-
-  test "with three segments" do
-    type = Oaken::Type.for("menu_item_detail_segments")
-
-    assert_consts type, [
-      "Menu::Item::Detail::Segment",
-      "Menu::Item::DetailSegment",
-      "Menu::ItemDetail::Segment",
-      "Menu::ItemDetailSegment",
-      "MenuItem::Detail::Segment",
-      "MenuItem::DetailSegment",
-      "MenuItemDetail::Segment",
-      "MenuItemDetailSegment"
-    ]
-    assert_nil type.locate
-  end
-
-  def assert_consts(type, expected)
-    assert_equal expected, type.send(:possible_consts).to_a
-  end
-end
-
 class OakenTest < ActiveSupport::TestCase
   test "version number" do
     refute_nil ::Oaken::VERSION

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -5,6 +5,21 @@ class OakenTest < ActiveSupport::TestCase
     refute_nil ::Oaken::VERSION
   end
 
+  test "derives types" do
+    names = Oaken::Type.for("Menu::Item::Detail::Segment").locate
+    p names
+
+    assert_equal \
+      ["Menu::Item::Detail::Segment",
+      "MenuItem::Detail::Segment",
+      "Menu::ItemDetail::Segment",
+      "MenuItemDetail::Segment",
+      "Menu::Item::DetailSegment",
+      "MenuItem::DetailSegment",
+      "Menu::ItemDetailSegment",
+      "MenuItemDetailSegment"], names
+  end
+
   test "accessing fixture" do
     assert_equal "Kasper", users.kasper.name
     assert_equal "Coworker", users.coworker.name

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -4,7 +4,7 @@ class Oaken::TypeTest < ActiveSupport::TestCase
   test "with zero segments" do
     type = Oaken::Type.for("users")
 
-    assert_consts type, ["User", "User"]
+    assert_consts type, ["User"]
     assert_equal User, type.locate
   end
 

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -38,12 +38,12 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "auto-registering with partial namespaces" do
-    Menu::HiddenDiscount = Class.new do
-      def self.table_name   = "menu_hidden_discounts"
-      def self.column_names = []
-    end
-
+    Menu::HiddenDiscount = Data.define(:column_names, :table_name).new([], "menu_hidden_discounts")
     assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_hidden_discounts
+
+    Menu::SuperSecret = Module.new
+    Menu::SuperSecret::Discount = Data.define(:column_names, :table_name).new([], "menu_super_secret_discounts")
+    assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_super_secret_discounts
   end
 
   test "global attributes" do

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -1,23 +1,59 @@
 require "test_helper"
 
+class Oaken::TypeTest < ActiveSupport::TestCase
+  test "with zero segments" do
+    type = Oaken::Type.for("users")
+
+    assert_consts type, ["User", "User"]
+    assert_equal User, type.locate
+  end
+
+  test "with one segment" do
+    type = Oaken::Type.for("menu_items")
+
+    assert_consts type, [
+      "Menu::Item",
+      "MenuItem"
+    ]
+    assert_equal Menu::Item, type.locate
+  end
+
+  test "with two segments" do
+    type = Oaken::Type.for("menu_item_details")
+
+    assert_consts type, [
+      "Menu::Item::Detail",
+      "Menu::ItemDetail",
+      "MenuItem::Detail",
+      "MenuItemDetail"
+    ]
+    assert_equal Menu::Item::Detail, type.locate
+  end
+
+  test "with three segments" do
+    type = Oaken::Type.for("menu_item_detail_segments")
+
+    assert_consts type, [
+      "Menu::Item::Detail::Segment",
+      "Menu::Item::DetailSegment",
+      "Menu::ItemDetail::Segment",
+      "Menu::ItemDetailSegment",
+      "MenuItem::Detail::Segment",
+      "MenuItem::DetailSegment",
+      "MenuItemDetail::Segment",
+      "MenuItemDetailSegment"
+    ]
+    assert_nil type.locate
+  end
+
+  def assert_consts(type, expected)
+    assert_equal expected, type.send(:possible_consts).to_a
+  end
+end
+
 class OakenTest < ActiveSupport::TestCase
   test "version number" do
     refute_nil ::Oaken::VERSION
-  end
-
-  test "derives types" do
-    names = Oaken::Type.for("Menu::Item::Detail::Segment").locate
-    p names
-
-    assert_equal \
-      ["Menu::Item::Detail::Segment",
-      "MenuItem::Detail::Segment",
-      "Menu::ItemDetail::Segment",
-      "MenuItemDetail::Segment",
-      "Menu::Item::DetailSegment",
-      "MenuItem::DetailSegment",
-      "Menu::ItemDetailSegment",
-      "MenuItemDetailSegment"], names
   end
 
   test "accessing fixture" do

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -38,11 +38,12 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "auto-registering with partial namespaces" do
-    Menu::HiddenDiscount = Data.define(:column_names, :table_name).new([], "menu_hidden_discounts")
+    klass = Struct.new(:column_names, :table_name)
+    Menu::HiddenDiscount = klass.new([], "menu_hidden_discounts")
     assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_hidden_discounts
 
     Menu::SuperSecret = Module.new
-    Menu::SuperSecret::Discount = Data.define(:column_names, :table_name).new([], "menu_super_secret_discounts")
+    Menu::SuperSecret::Discount = klass.new([], "menu_super_secret_discounts")
     assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_super_secret_discounts
   end
 


### PR DESCRIPTION
Fixes #102

I'm not sure about the internals of this or whether I ought to ship it.

----

We're trying to match something like `menu_item_details`, e.g. `MenuItemDetail` to all the possible Ruby const names and lazily generating and constantizing each.

So in the case of `MenuItemDetail` there's 2 possible spots to insert a separator, between `Menu`, `Item`, and `Detail`. The separators are either `"::"` or `""`. Which means there's 2² possible combinations.