### PR TITLE
Fix Oaken expecting Rails test parallelization.

### DIFF
--- a/lib/oaken/test_setup.rb
+++ b/lib/oaken/test_setup.rb
@@ -12,7 +12,8 @@ module Oaken::TestSetup
     #
     # So we prepend into `before_setup` and later `super` to have fixtures wrap tests in transactions.
     def before_setup
-      unless Minitest.parallel_executor.send(:should_parallelize?)
+      # `should_parallelize?` is only defined when Rails' test `parallelize` macro has been called.
+      unless Minitest.parallel_executor.then { _1.respond_to?(:should_parallelize?, true) && _1.send(:should_parallelize?) }
         ActiveRecord::Tasks::DatabaseTasks.truncate_all # Mimic fixtures by truncating before inserting.
         Oaken.load_seed
       end


### PR DESCRIPTION
In case `parallelize` hasn't been called, `should_parallelize?` isn't defined and we must truncate + load the seeds.

Fixes https://github.com/kaspth/oaken/issues/104