### PR TITLE
Don't use `table_name` + support `as:` on `register`

### DIFF
--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -20,7 +20,7 @@ module Oaken::Seeds
   # If you have classes that don't follow these naming conventions, you must call `register` manually.
   def self.method_missing(meth, ...)
     if type = Oaken::Type.for(meth.to_s).locate
-      register type
+      register type, as: meth
       public_send(meth, ...)
     else
       super
@@ -33,11 +33,15 @@ module Oaken::Seeds
   #
   #   register Account, Account::Job, Account::Job::Task
   #
-  # Oaken uses the `table_name` of the passed classes for the method names, e.g. here they'd be
+  # Oaken uses `name.tableize.tr("/", "_")` on the passed classes for the method names, so they're
   # `accounts`, `account_jobs`, and `account_job_tasks`, respectively.
-  def self.register(*types)
+  #
+  # You can also pass an explicit `as:` option, if you'd like:
+  #
+  #   register User, as: :something_else
+  def self.register(*types, as: nil)
     types.each do |type|
-      stored = provider.new(type) and define_method(stored.key) { stored }
+      stored = provider.new(type) and define_method(as || type.name.tableize.tr("/", "_")) { stored }
     end
   end
   def self.provider = Oaken::Stored::ActiveRecord

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -1,9 +1,9 @@
 class Oaken::Stored::ActiveRecord
   def initialize(type)
-    @type, @key = type, type.table_name
+    @type = type
     @attributes = Oaken::Seeds.defaults_for(*type.column_names)
   end
-  attr_reader :type, :key
+  attr_reader :type
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
   delegate :find, :insert_all, :pluck, to: :type
 

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -38,13 +38,18 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "auto-registering with partial namespaces" do
-    klass = Struct.new(:column_names, :table_name)
-    Menu::HiddenDiscount = klass.new([], "menu_hidden_discounts")
+    Menu::HiddenDiscount = Class.new { def self.column_names = [] }
     assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_hidden_discounts
 
     Menu::SuperSecret = Module.new
-    Menu::SuperSecret::Discount = klass.new([], "menu_super_secret_discounts")
+    Menu::SuperSecret::Discount = Class.new { def self.column_names = [] }
     assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.menu_super_secret_discounts
+  end
+
+  test "registering with custom alias" do
+    Oaken::Seeds.register User, as: :aliased_users
+    assert_kind_of Oaken::Stored::ActiveRecord, aliased_users
+    assert_kind_of Oaken::Stored::ActiveRecord, Oaken::Seeds.aliased_users
   end
 
   test "global default attributes" do


### PR DESCRIPTION
Fixes https://github.com/kaspth/oaken/issues/109

Oaken's seed files are meant to look like data scripts, which means the `users` in `users.create`, uses a logical name that resolves to a User.

However, we'd come back around and try to use the `table_name` to derive the method name, which may have a prefix and/or suffix that we don't care about. The developer using Oaken has already told us what name they expect because of how they triggered the `method_missing`, so as long as we can resolve that into a type we're good.

If there's cases where that doesn't match, we'll also allow `register User, as: :aliased_users` so you can have it however you want.