### PR TITLE
Restructure around `Oaken.loader`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.25.5)
     net-imap (0.5.6)
       date
@@ -126,6 +127,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.17.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.17.2-x86_64-linux)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ So if you call `Oaken.loader.seed :accounts`, we'll look within `db/seeds/` and 
 - and so on.
 
 > [!TIP]
+> You can call `Oaken.loader.glob` with a single identifier to see what files we'll match. > Some samples: `Oaken.loader.glob :accounts`, `Oaken.loader.glob "cases/pagination"`.
+
+> [!TIP]
 > Putting a file in the top-level `db/seeds` versus `db/seeds/development` or `db/seeds/test` means it's shared in both environments. See below for more tips.
 
 Any directories and/or single-file matches are loaded in the order they're specified. So `loader.seed :setup, :accounts` would first load setup and then accounts.

--- a/README.md
+++ b/README.md
@@ -259,19 +259,16 @@ You can customize the loading and loader as well:
 
 ```ruby
 # config/initializers/oaken.rb
-Oaken.loader.root = "test/seeds" # Useful to pull from another directory, when migrating.
-Oaken.loader.subpaths << Rails.env # Oaken passes Rails.env like this, but you can pass extra subpaths or clear them.
-
 # Call `with` to build a new loader. Here we're just passing the default internal options:
+loader = Oaken.loader.with(lookup_paths: "test/seeds") # Useful to pull from another directory, when migrating.
 loader = Oaken.loader.with(locator: Oaken::Loader::Type, provider: Oaken::Stored::ActiveRecord, context: Oaken::Seeds)
 
-# You can also replace Oaken's default loader.
-Oaken.loader = loader
+Oaken.loader = loader # You can also replace Oaken's default loader.
 ```
 
 > [!TIP]
 > `Oaken` delegates `Oaken::Loader`'s public instance methods to `loader`,
-> so `Oaken.seed` works and is really `Oaken.loader.seed`. Same goes for `Oaken.root`, `Oaken.subpaths`, `Oaken.with` and more.
+> so `Oaken.seed` works and is really `Oaken.loader.seed`. Same goes for `Oaken.lookup_paths`, `Oaken.with`, `Oaken.glob` and more.
 
 #### In db/seeds.rb
 

--- a/README.md
+++ b/README.md
@@ -167,29 +167,41 @@ Any directories and/or single-file matches are loaded in the order they're speci
 > [!IMPORTANT]
 > Understanding and making effective use of Oaken's directory loading will pay dividends for your usage. You generally want to have 1 top-level directive `seed` call to dictate how seeding happens in e.g. `db/seeds.rb` and then let individual seed files load in no specified order within that.
 
+#### Using the `setup` phase
+
+When you call `Oaken.loader.seed` we'll also call `seed :setup` behind the scenes, though we'll only call this once. It's meant for common setup, like `defaults` and helpers.
+
+> [!IMPORTANT]
+> We recommend you don't use `create`/`upsert` directly in setup. Add the `defaults` and/or helpers that would be useful in the later seed files.
+
+Here's some files you could add:
+
+- db/seeds/setup.rb — particularly useful as a starting point.
+- db/seeds/setup/defaults.rb — loader and type-specific defaults.
+- db/seeds/setup/defaults/*.rb — you could split out more specific files.
+- db/seeds/setup/users.rb — a type specific file for its defaults/helpers, doesn't have to just be users.
+
+- db/seeds/development/setup.rb — some defaults/helpers we only want in development.
+- db/seeds/test/setup.rb — some defaults/helpers we only want in test.
+
+> [!TIP]
+> Remember, since we're using `seed` internally you can nest as deeply as you want to structure however works best. There's tons of flexibility in the `**/*` glob pattern `seed` uses.
+
 #### Directory recommendations & file tips
 
 Oaken has some directory recommendations to help strengthen your understanding of your object graph:
 
-- Group scenarios around your top-level root model, like `Account`, `Team`, or `Organization` and have a `db/seeds/accounts` directory.
-- `db/seeds/setup` for `defaults` and helpers. See below.
 - `db/seeds/data` for any data tables, like the plans a SaaS app has.
+- Group scenarios around your top-level root model, like `Account`, `Team`, or `Organization` and have a `db/seeds/accounts` directory.
 - `db/seeds/cases` for any specific cases, like pagination.
 
 If you follow all these conventions you could do this:
 
 ```ruby
-Oaken.loader.seed :setup, :data, :accounts, :cases
+Oaken.loader.seed :data, :accounts, :cases
 ```
 
 And here's some potential file suggestions you could take advantage of:
-
-- db/seeds/setup.rb — particularly useful as a starting point. Due to the flexible loading, you can add a subdirectory or file later within and it'll be picked up.
-- db/seeds/setup/defaults.rb — loader and type-specific defaults.
-- db/seeds/setup/users.rb — user specific defaults/helpers.
-
-- db/seeds/development/setup.rb — some defaults/helpers we only want in development.
-- db/seeds/test/setup.rb — some defaults/helpers we only want in test.
 
 - db/seeds/data/plans.rb — put your SaaS plans in here.
 - db/seeds/test/data/plans.rb — some test specific plans, in case we need them.
@@ -198,7 +210,7 @@ And here's some potential file suggestions you could take advantage of:
 - db/seeds/test/cases/*.rb — any test specific cases.
 
 > [!TIP]
-> We're letting Oaken's loading do all the hard work here, we're just specifying the top-level order.
+> We're letting Oaken's loading do all the hard work here, we're just staging the loading phases by specifying the top-level order.
 
 ##### Loading specific cases in tests only
 

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -16,7 +16,7 @@ module Oaken
 
   singleton_class.attr_accessor :loader
   singleton_class.delegate *Loader.public_instance_methods(false), to: :loader
-  @loader = Loader.new root: "db/seeds"
+  @loader = Loader.new lookup_paths: "db/seeds"
 end
 
 require_relative "oaken/railtie" if defined?(Rails::Railtie)

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -8,34 +8,15 @@ module Oaken
 
   autoload :Loader,    "oaken/loader"
   autoload :Seeds,     "oaken/seeds"
-  autoload :Type,      "oaken/type"
   autoload :TestSetup, "oaken/test_setup"
 
   module Stored
     autoload :ActiveRecord, "oaken/stored/active_record"
   end
 
-  singleton_class.attr_reader :lookup_paths
-  @lookup_paths = ["db/seeds"]
-
-  def self.glob(identifier)
-    patterns = lookup_paths.map { File.join _1, "#{identifier}{,/**/*}.rb" }
-
-    Pathname.glob(patterns).tap do |found|
-      raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}" if found.none?
-    end
-  end
-  NoSeedsFoundError = Class.new ArgumentError
-
-  def self.prepare(&block)
-    Seeds.instance_eval(&block)
-  end
-
-  def self.replant_seed
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
-    load_seed
-  end
-  def self.load_seed = Rails.application.load_seed
+  singleton_class.attr_accessor :loader
+  singleton_class.delegate *Loader.public_instance_methods(false), to: :loader
+  @loader = Loader.new root: "db/seeds"
 end
 
 require_relative "oaken/railtie" if defined?(Rails::Railtie)

--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -6,6 +6,7 @@ require "pathname"
 module Oaken
   class Error < StandardError; end
 
+  autoload :Loader,    "oaken/loader"
   autoload :Seeds,     "oaken/seeds"
   autoload :Type,      "oaken/type"
   autoload :TestSetup, "oaken/test_setup"
@@ -25,28 +26,6 @@ module Oaken
     end
   end
   NoSeedsFoundError = Class.new ArgumentError
-
-  class Loader
-    def self.from(identifiers)
-      new identifiers.flat_map { Oaken.glob _1 }
-    end
-
-    def initialize(entries)
-      @entries = entries
-    end
-
-    def load_onto(seeds) = @entries.each do |path|
-      ActiveRecord::Base.transaction do
-        seeds.class_eval path.read, path.to_s
-      end
-    end
-
-    def self.definition_location
-      # Trickery abounds! Due to Ruby's `caller_locations` + our `load_onto`'s `class_eval` above
-      # we can use this format to detect the location in the seed file where the call came from.
-      caller_locations(2, 8).find { _1.label.match? /block .*?load_onto/ }
-    end
-  end
 
   def self.prepare(&block)
     Seeds.instance_eval(&block)

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -3,31 +3,83 @@
 class Oaken::Loader
   class NoSeedsFoundError < ArgumentError; end
 
+  class Pathset
+    attr_reader :root, :subpaths
+    define_method(:root=) { @root = Pathname(_1) }
+    define_method(:subpaths=) { @subpaths = [".", *_1].uniq }
+
+    def initialize(root:, subpaths:)
+      self.root, self.subpaths = root, subpaths
+    end
+
+    def glob(identifier)
+      Pathname.glob subpaths.map { root.join _1, "#{identifier}{,/**/*}.rb" }
+    end
+  end
+
   autoload :Type, "oaken/loader/type"
+
+  attr_reader :pathset, :locator, :provider, :context
+  delegate :root, :root=, :subpaths, :subpaths=, to: :pathset
+  delegate :locate, to: :locator
 
   def initialize(root:, subpaths: nil, locator: Type, provider: Oaken::Stored::ActiveRecord, context: Oaken::Seeds)
     @pathset, @locator, @provider, @context = Pathset.new(root:, subpaths:), locator, provider, context
     @defaults = {}.with_indifferent_access
   end
-  attr_reader :pathset, :locator, :provider, :context
-  delegate :locate, to: :locator
-  delegate :root, :root=, :subpaths, :subpaths=, to: :pathset
 
-  def with(**options)
-    self.class.new(root:, subpaths:, locator:, provider:, context:, **options)
+  # Instantiate a new loader with all its attributes and any specified `overrides`. See #new for defaults.
+  #
+  #   Oaken.loader.with(root: "test/fixtures") # `root` returns "test/fixtures" here
+  def with(**overrides)
+    self.class.new(root:, subpaths:, locator:, provider:, context:, **overrides)
   end
 
-  # Allow assigning defaults across different types.
+  # Allow assigning defaults across types.
   def defaults(**defaults) = @defaults.merge!(**defaults)
   def defaults_for(*keys)  = @defaults.slice(*keys)
+
+  def test_setup
+    Oaken::TestSetup.new self
+  end
+
+  # Register a model class via `Oaken.loader.context`.
+  # Note: Oaken's auto-register means you don't need to call `register` often yourself.
+  #
+  #   register Account, Account::Job, Account::Job::Task
+  #
+  # Oaken uses `name.tableize.tr("/", "_")` for the method names, so they're
+  # `accounts`, `account_jobs`, and `account_job_tasks`, respectively.
+  #
+  # You can also pass an explicit `as:` option:
+  #
+  #   register User, as: :something_else
+  def register(*types, as: nil)
+    types.each do |type|
+      stored = provision(type) and context.define_method(as || type.name.tableize.tr("/", "_")) { stored }
+    end
+  end
+
+  def provision(type)
+    provider.new(self, type)
+  end
+
+  # Mirrors `bin/rails db:seed:replant`.
+  def replant_seed
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    load_seed
+  end
+
+  # Mirrors `bin/rails db:seed`.
+  def load_seed
+    Rails.application.load_seed
+  end
 
   # Set up a general seed rule or perform a one-off seed for a test file.
   #
   # You can set up a general seed rule in `db/seeds.rb` like this:
   #
-  #   Oaken.prepare do
-  #     seed :accounts # Seeds from `db/seeds/accounts/**/*.rb` and `db/seeds/<Rails.env>/accounts/**/*.rb`
-  #   end
+  #   Oaken.seed :accounts # Seeds from `db/seeds/accounts{,/**/*}.rb` and `db/seeds/<Rails.env>/accounts{,/**/*}.rb`
   #
   # Then if you need a test specific scenario, we recommend putting them in `db/seeds/test/cases`.
   #
@@ -42,21 +94,6 @@ class Oaken::Loader
     self
   end
 
-  def test_setup
-    Oaken::TestSetup.new self
-  end
-
-  def provided(type)
-    provider.new(self, type)
-  end
-
-  def replant_seed
-    truncate_all
-    load_seed
-  end
-  def truncate_all = ActiveRecord::Tasks::DatabaseTasks.truncate_all
-  def load_seed = Rails.application.load_seed
-
   def definition_location
     # Trickery abounds! Due to Ruby's `caller_locations` + our `load_one`'s `class_eval` above
     # we can use this format to detect the location in the seed file where the call came from.
@@ -65,26 +102,11 @@ class Oaken::Loader
 
   private
     def glob!(identifier)
-      pathset.glob(identifier).then.find(&:any?) or
-        raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}"
+      pathset.glob(identifier).then.find(&:any?) or raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}"
     end
 
     def load_one(path)
       context.class_eval path.read, path.to_s
     end
     LABEL = instance_method(:load_one).name.to_s
-
-  class Pathset
-    attr_reader :root, :subpaths
-    define_method(:root=) { @root = Pathname(_1) }
-    define_method(:subpaths=) { @subpaths = [".", *_1].uniq }
-
-    def initialize(root:, subpaths:)
-      self.root, self.subpaths = root, subpaths
-    end
-
-    def glob(identifier)
-      Pathname.glob subpaths.map { root.join _1, "#{identifier}{,/**/*}.rb" }
-    end
-  end
 end

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -92,9 +92,8 @@ class Oaken::Loader
   end
 
   def definition_location
-    # Trickery abounds! Due to Ruby's `caller_locations` + our `load_one`'s `class_eval` above
-    # we can use this format to detect the location in the seed file where the call came from.
-    caller_locations(2, 8).find { _1.label == LABEL }
+    # The first line referencing LABEL happens to be the line in the seed file.
+    caller_locations(3, 6).find { _1.base_label == LABEL }
   end
 
   private

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -58,7 +58,7 @@ class Oaken::Loader
   #   register User, as: :something_else
   def register(type, as: nil)
     stored = provider.new(self, type)
-    context.define_method(as || type.name.tableize.tr("/", "_")) { stored }
+    context.define_method(as || stored.method_name) { stored }
   end
 
   # Mirrors `bin/rails db:seed:replant`.

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -58,7 +58,7 @@ class Oaken::Loader
   #   register User, as: :something_else
   def register(type, as: nil)
     stored = provider.new(self, type)
-    context.define_method(as || stored.method_name) { stored }
+    context.define_method(as || type.name.tableize.tr("/", "_")) { stored }
   end
 
   # Mirrors `bin/rails db:seed:replant`.

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -20,7 +20,7 @@ class Oaken::Loader
   autoload :Type, "oaken/loader/type"
 
   attr_reader :pathset, :locator, :provider, :context
-  delegate :root, :root=, :subpaths, :subpaths=, to: :pathset
+  delegate *Pathset.public_instance_methods(false), to: :pathset
   delegate :locate, to: :locator
 
   def initialize(root:, subpaths: nil, locator: Type, provider: Oaken::Stored::ActiveRecord, context: Oaken::Seeds)
@@ -105,7 +105,6 @@ class Oaken::Loader
     def glob!(identifier)
       glob(identifier).then.find(&:any?) or raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}"
     end
-    delegate :glob, to: :pathset
 
     def load_one(path)
       context.class_eval path.read, path.to_s

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -46,7 +46,9 @@ class Oaken::Loader
   # Register a model class via `Oaken.loader.context`.
   # Note: Oaken's auto-register means you don't need to call `register` often yourself.
   #
-  #   register Account, Account::Job, Account::Job::Task
+  #   register Account
+  #   register Account::Job
+  #   register Account::Job::Task
   #
   # Oaken uses `name.tableize.tr("/", "_")` for the method names, so they're
   # `accounts`, `account_jobs`, and `account_job_tasks`, respectively.
@@ -54,14 +56,9 @@ class Oaken::Loader
   # You can also pass an explicit `as:` option:
   #
   #   register User, as: :something_else
-  def register(*types, as: nil)
-    types.each do |type|
-      stored = provision(type) and context.define_method(as || type.name.tableize.tr("/", "_")) { stored }
-    end
-  end
-
-  def provision(type)
-    provider.new(self, type)
+  def register(type, as: nil)
+    stored = provider.new(self, type)
+    context.define_method(as || type.name.tableize.tr("/", "_")) { stored }
   end
 
   # Mirrors `bin/rails db:seed:replant`.

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -1,0 +1,21 @@
+class Oaken::Loader
+  def self.from(identifiers)
+    new identifiers.flat_map { Oaken.glob _1 }
+  end
+
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def load_onto(seeds) = @entries.each do |path|
+    ActiveRecord::Base.transaction do
+      seeds.class_eval path.read, path.to_s
+    end
+  end
+
+  def self.definition_location
+    # Trickery abounds! Due to Ruby's `caller_locations` + our `load_onto`'s `class_eval` above
+    # we can use this format to detect the location in the seed file where the call came from.
+    caller_locations(2, 8).find { _1.label.match? /block .*?load_onto/ }
+  end
+end

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -1,21 +1,90 @@
+# frozen_string_literal: true
+
 class Oaken::Loader
-  def self.from(identifiers)
-    new identifiers.flat_map { Oaken.glob _1 }
+  class NoSeedsFoundError < ArgumentError; end
+
+  autoload :Type, "oaken/loader/type"
+
+  def initialize(root:, subpaths: nil, locator: Type, provider: Oaken::Stored::ActiveRecord, context: Oaken::Seeds)
+    @pathset, @locator, @provider, @context = Pathset.new(root:, subpaths:), locator, provider, context
+    @defaults = {}.with_indifferent_access
+  end
+  attr_reader :pathset, :locator, :provider, :context
+  delegate :locate, to: :locator
+  delegate :root, :root=, :subpaths, :subpaths=, to: :pathset
+
+  def with(**options)
+    self.class.new(root:, subpaths:, locator:, provider:, context:, **options)
   end
 
-  def initialize(entries)
-    @entries = entries
+  # Allow assigning defaults across different types.
+  def defaults(**defaults) = @defaults.merge!(**defaults)
+  def defaults_for(*keys)  = @defaults.slice(*keys)
+
+  # Set up a general seed rule or perform a one-off seed for a test file.
+  #
+  # You can set up a general seed rule in `db/seeds.rb` like this:
+  #
+  #   Oaken.prepare do
+  #     seed :accounts # Seeds from `db/seeds/accounts/**/*.rb` and `db/seeds/<Rails.env>/accounts/**/*.rb`
+  #   end
+  #
+  # Then if you need a test specific scenario, we recommend putting them in `db/seeds/test/cases`.
+  #
+  # Say you have `db/seeds/test/cases/pagination.rb`, you can load it like this:
+  #
+  #   # test/integration/pagination_test.rb
+  #   class PaginationTest < ActionDispatch::IntegrationTest
+  #     setup { seed "cases/pagination" }
+  #   end
+  def seed(*identifiers)
+    identifiers.flat_map { glob! _1 }.each { load_one _1 }
+    self
   end
 
-  def load_onto(seeds) = @entries.each do |path|
-    ActiveRecord::Base.transaction do
-      seeds.class_eval path.read, path.to_s
-    end
+  def test_setup
+    Oaken::TestSetup.new self
   end
 
-  def self.definition_location
-    # Trickery abounds! Due to Ruby's `caller_locations` + our `load_onto`'s `class_eval` above
+  def provided(type)
+    provider.new(self, type)
+  end
+
+  def replant_seed
+    truncate_all
+    load_seed
+  end
+  def truncate_all = ActiveRecord::Tasks::DatabaseTasks.truncate_all
+  def load_seed = Rails.application.load_seed
+
+  def definition_location
+    # Trickery abounds! Due to Ruby's `caller_locations` + our `load_one`'s `class_eval` above
     # we can use this format to detect the location in the seed file where the call came from.
-    caller_locations(2, 8).find { _1.label.match? /block .*?load_onto/ }
+    caller_locations(2, 8).find { _1.label == LABEL }
+  end
+
+  private
+    def glob!(identifier)
+      pathset.glob(identifier).then.find(&:any?) or
+        raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}"
+    end
+
+    def load_one(path)
+      context.class_eval path.read, path.to_s
+    end
+    LABEL = instance_method(:load_one).name.to_s
+
+  class Pathset
+    attr_reader :root, :subpaths
+    define_method(:root=) { @root = Pathname(_1) }
+    define_method(:subpaths=) { @subpaths = [".", *_1].uniq }
+
+    def initialize(root:, subpaths:)
+      self.root, self.subpaths = root, subpaths
+    end
+
+    def glob(identifier)
+      Pathname.glob subpaths.map { root.join _1, "#{identifier}{,/**/*}.rb" }
+    end
   end
 end

--- a/lib/oaken/loader/type.rb
+++ b/lib/oaken/loader/type.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class Oaken::Type < Struct.new(:name, :gsub)
+class Oaken::Loader::Type < Struct.new(:name, :gsub)
+  def self.locate(name) = self.for(name.to_s).locate
   def self.for(name) = new(name, name.classify.gsub(/(?<=[a-z])(?=[A-Z])/))
 
   def locate

--- a/lib/oaken/railtie.rb
+++ b/lib/oaken/railtie.rb
@@ -1,7 +1,7 @@
 module Oaken
   class Railtie < Rails::Railtie
     initializer "oaken.lookup_paths" do
-      Oaken.subpaths << Rails.env
+      Oaken.lookup_paths << "db/seeds/#{Rails.env}"
     end
   end
 end

--- a/lib/oaken/railtie.rb
+++ b/lib/oaken/railtie.rb
@@ -1,7 +1,7 @@
 module Oaken
   class Railtie < Rails::Railtie
     initializer "oaken.lookup_paths" do
-      Oaken.lookup_paths << "db/seeds/#{Rails.env}"
+      Oaken.subpaths << Rails.env
     end
   end
 end

--- a/lib/oaken/rspec_setup.rb
+++ b/lib/oaken/rspec_setup.rb
@@ -1,8 +1,5 @@
 RSpec.configure do |config|
-  config.include Oaken::Seeds
+  config.include Oaken.loader.context
   config.use_transactional_fixtures = true
-
-  config.before :suite do
-    Oaken.replant_seed
-  end
+  config.before(:suite) { Oaken.loader.replant_seed }
 end

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -1,16 +1,6 @@
-module Oaken::Seeds
-  extend self
-
+module Oaken::Seeds extend self
   def self.loader = Oaken.loader
   singleton_class.delegate :seed, to: :loader
-
-  # Call `seed` in tests to load individual case files:
-  #
-  #   class PaginationTest < ActionDispatch::IntegrationTest
-  #     setup do
-  #       seed "cases/pagination" # Loads `db/seeds/{,test}/cases/pagination{,**/*}.rb`
-  #     end
-  #   end
   delegate :seed, to: self
 
   # Oaken's main auto-registering logic.

--- a/lib/oaken/seeds.rb
+++ b/lib/oaken/seeds.rb
@@ -1,10 +1,17 @@
 module Oaken::Seeds
   extend self
 
-  # Allow assigning defaults across different types.
-  def self.defaults(**defaults) = attributes.merge!(**defaults)
-  def self.defaults_for(*keys) = attributes.slice(*keys)
-  def self.attributes = @attributes ||= {}.with_indifferent_access
+  def self.loader = Oaken.loader
+  singleton_class.delegate :seed, to: :loader
+
+  # Call `seed` in tests to load individual case files:
+  #
+  #   class PaginationTest < ActionDispatch::IntegrationTest
+  #     setup do
+  #       seed "cases/pagination" # Loads `db/seeds/{,test}/cases/pagination{,**/*}.rb`
+  #     end
+  #   end
+  delegate :seed, to: self
 
   # Oaken's main auto-registering logic.
   #
@@ -19,14 +26,14 @@ module Oaken::Seeds
   #
   # If you have classes that don't follow these naming conventions, you must call `register` manually.
   def self.method_missing(meth, ...)
-    if type = Oaken::Type.for(meth.to_s).locate
+    if type = loader.locate(meth)
       register type, as: meth
       public_send(meth, ...)
     else
       super
     end
   end
-  def self.respond_to_missing?(meth, ...) = Oaken::Type.for(meth.to_s).locate || super
+  def self.respond_to_missing?(meth, ...) = loader.locate(meth) || super
 
   # Register a model class to be accessible as an instance method via `include Oaken::Seeds`.
   # Note: Oaken's auto-register via `method_missing` means it's less likely you need to call this manually.
@@ -41,62 +48,28 @@ module Oaken::Seeds
   #   register User, as: :something_else
   def self.register(*types, as: nil)
     types.each do |type|
-      stored = provider.new(type) and define_method(as || type.name.tableize.tr("/", "_")) { stored }
-    end
-  end
-  def self.provider = Oaken::Stored::ActiveRecord
-
-  class << self
-    # Set up a general seed rule or perform a one-off seed for a test file.
-    #
-    # You can set up a general seed rule in `db/seeds.rb` like this:
-    #
-    #   Oaken.prepare do
-    #     seed :accounts # Seeds from `db/seeds/accounts/**/*.rb` and `db/seeds/<Rails.env>/accounts/**/*.rb`
-    #   end
-    #
-    # Then if you need a test specific scenario, we recommend putting them in `db/seeds/test/cases`.
-    #
-    # Say you have `db/seeds/test/cases/pagination.rb`, you can load it like this:
-    #
-    #   # test/integration/pagination_test.rb
-    #   class PaginationTest < ActionDispatch::IntegrationTest
-    #     setup { seed "cases/pagination" }
-    #   end
-    def seed(*identifiers)
-      Oaken::Loader.from(identifiers).load_onto self
-    end
-
-    # `section` is purely for decorative purposes to carve up `Oaken.prepare` and seed files.
-    #
-    #   Oaken.prepare do
-    #     section :roots # Just the very few top-level models like Accounts and Users.
-    #     users.defaults email_address: -> { Faker::Internet.email }, webauthn_id: -> { SecureRandom.hex }
-    #
-    #     section :stems # Models building on the roots.
-    #
-    #     section :leafs # Remaining models, bulk of them, hanging off root and stem models.
-    #
-    #     section do
-    #       seed :accounts, :data
-    #     end
-    #   end
-    #
-    # Since `section` is defined as `def section(*, **) = yield if block_given?`, you can use
-    # all of Ruby's method signature flexibility to help communicate structure better.
-    #
-    # Use positional and keyword arguments, or use blocks to indent them, or combine them all.
-    def section(*, **)
-      yield if block_given?
+      stored = loader.provided(type) and define_method(as || type.name.tableize.tr("/", "_")) { stored }
     end
   end
 
-  # Call `seed` in tests to load individual case files:
+  # `section` is purely for decorative purposes to carve up `Oaken.prepare` and seed files.
   #
-  #   class PaginationTest < ActionDispatch::IntegrationTest
-  #     setup do
-  #       seed "cases/pagination" # Loads `db/seeds/{,test}/cases/pagination{,**/*}.rb`
+  #   Oaken.prepare do
+  #     section :roots # Just the very few top-level models like Accounts and Users.
+  #     users.defaults email_address: -> { Faker::Internet.email }, webauthn_id: -> { SecureRandom.hex }
+  #
+  #     section :stems # Models building on the roots.
+  #
+  #     section :leafs # Remaining models, bulk of them, hanging off root and stem models.
+  #
+  #     section do
+  #       seed :accounts, :data
   #     end
   #   end
-  delegate :seed, to: Oaken::Seeds
+  #
+  # Since `section` is defined as `def section(*, **) = block_given? && yield`, you can use
+  # all of Ruby's method signature flexibility to help communicate structure better.
+  #
+  # Use positional and keyword arguments, or use blocks to indent them, or combine them all.
+  def self.section(*, **) = block_given? && yield
 end

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -7,10 +7,6 @@ class Oaken::Stored::ActiveRecord
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
   delegate :find, :insert_all, :pluck, to: :type
 
-  def method_name
-    type.name.tableize.tr("/", "_")
-  end
-
   def create(label = nil, unique_by: nil, **attributes)
     attributes = attributes_for(**attributes)
 

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -47,10 +47,7 @@ class Oaken::Stored::ActiveRecord
   #
   #   users.defaults name: -> { Faker::Name.name } # This `name` takes precedence on `users`.
   #   users.create # => Uses the users' default `name` and the loader `email_address`
-  def defaults(**attributes)
-    @attributes = @attributes.merge(attributes)
-    @attributes
-  end
+  def defaults(**attributes) = @attributes = @attributes.merge(attributes)
 
   # Expose a record instance that's setup outside of using `create`/`upsert`. Like this:
   #
@@ -65,9 +62,7 @@ class Oaken::Stored::ActiveRecord
   #   users.label someone:, someone_else:
   #
   # Note: `users.method(:someone).source_location` also points back to the file and line of the `label` call.
-  def label(**labels)
-    labels.each { |label, record| _label label, record.id }
-  end
+  def label(**labels) = labels.each { |label, record| _label label, record.id }
 
   private def _label(name, id)
     raise ArgumentError, "you can only define labelled records outside of tests" \

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -1,7 +1,7 @@
 class Oaken::Stored::ActiveRecord
-  def initialize(type)
-    @type = type
-    @attributes = Oaken::Seeds.defaults_for(*type.column_names)
+  def initialize(loader, type)
+    @loader, @type = loader, type
+    @attributes = loader.defaults_for(*type.column_names)
   end
   attr_reader :type
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
@@ -76,7 +76,7 @@ class Oaken::Stored::ActiveRecord
 
   private def _label(name, id)
     raise ArgumentError, "you can only define labelled records outside of tests" \
-      unless location = Oaken::Loader.definition_location
+      unless location = @loader.definition_location
 
     class_eval "def #{name} = find(#{id.inspect})", location.path, location.lineno
   end

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -15,7 +15,7 @@ class Oaken::Stored::ActiveRecord
     record   = type.find_by(finders)&.tap { _1.update!(**attributes) } if finders.any?
     record ||= type.create!(**attributes)
 
-    label label => record if label
+    _label label, record.id if label
     record
   end
 
@@ -25,7 +25,7 @@ class Oaken::Stored::ActiveRecord
 
     type.new(attributes).validate!
     record = type.new(id: type.upsert(attributes, unique_by: unique_by, returning: :id).rows.first.first)
-    label label => record if label
+    _label label, record.id if label
     record
   end
 
@@ -65,8 +65,8 @@ class Oaken::Stored::ActiveRecord
   def label(**labels) = labels.each { |label, record| _label label, record.id }
 
   private def _label(name, id)
-    raise ArgumentError, "you can only define labelled records outside of tests" \
-      unless location = @loader.definition_location
+    location = @loader.definition_location or
+      raise ArgumentError, "you can only define labelled records outside of tests"
 
     class_eval "def #{name} = find(#{id.inspect})", location.path, location.lineno
   end

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -7,6 +7,10 @@ class Oaken::Stored::ActiveRecord
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
   delegate :find, :insert_all, :pluck, to: :type
 
+  def method_name
+    type.name.tableize.tr("/", "_")
+  end
+
   def create(label = nil, unique_by: nil, **attributes)
     attributes = attributes_for(**attributes)
 

--- a/lib/oaken/test_setup.rb
+++ b/lib/oaken/test_setup.rb
@@ -9,12 +9,13 @@ class Oaken::TestSetup < Module
     define_method :before_setup do
       # `should_parallelize?` is only defined when Rails' test `parallelize` macro has been called.
       loader.replant_seed unless Minitest.parallel_executor.then { _1.respond_to?(:should_parallelize?, true) && _1.send(:should_parallelize?) }
+
       instance.remove_method :before_setup # Only run once, so remove before passing to fixtures in `super`.
       super()
     end
   end
 
-  def prepended(klass)
+  def included(klass)
     klass.fixtures # Rely on fixtures to setup a shared connection pool and wrap tests in transactions.
     klass.include @loader.context
     klass.parallelize_setup { @loader.load_seed } # No need to truncate as parallel test databases are always empty.

--- a/lib/oaken/test_setup.rb
+++ b/lib/oaken/test_setup.rb
@@ -1,22 +1,22 @@
-module Oaken::TestSetup
-  include Oaken::Seeds
+class Oaken::TestSetup < Module
+  def initialize(loader)
+    @loader = loader
 
-  def self.included(klass)
-    klass.fixtures # Rely on fixtures to setup a shared connection pool and wrap tests in transactions.
-    klass.parallelize_setup { Oaken.load_seed } # No need to truncate as parallel test databases are always empty.
-    klass.prepend BeforeSetup
-  end
-
-  module BeforeSetup
     # We must inject late enough to call `should_parallelize?`, but before fixtures' `before_setup`.
     #
     # So we prepend into `before_setup` and later `super` to have fixtures wrap tests in transactions.
-    def before_setup
+    instance = self
+    define_method :before_setup do
       # `should_parallelize?` is only defined when Rails' test `parallelize` macro has been called.
-      Oaken.replant_seed unless Minitest.parallel_executor.then { _1.respond_to?(:should_parallelize?, true) && _1.send(:should_parallelize?) }
-
-      Oaken::TestSetup::BeforeSetup.remove_method :before_setup # Only run once, so remove before passing to fixtures in `super`.
-      super
+      loader.replant_seed unless Minitest.parallel_executor.then { _1.respond_to?(:should_parallelize?, true) && _1.send(:should_parallelize?) }
+      instance.remove_method :before_setup # Only run once, so remove before passing to fixtures in `super`.
+      super()
     end
+  end
+
+  def prepended(klass)
+    klass.fixtures # Rely on fixtures to setup a shared connection pool and wrap tests in transactions.
+    klass.include @loader.context
+    klass.parallelize_setup { @loader.load_seed } # No need to truncate as parallel test databases are always empty.
   end
 end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,20 +1,3 @@
 ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV["VERBOSE"] || ENV["CI"]
 
-Oaken.prepare do
-  defaults name: -> { "Shouldn't be used for users.name" }, title: -> { "Global Default Title" }
-
-  section :roots
-  user_counter, email_address_counter = 0, 0
-  users.defaults name: -> { "Customer #{user_counter += 1}" },
-    email_address: -> { "email_address#{email_address_counter += 1}@example.com" }
-  def users.create(*, unique_by: :email_address, **o) = super
-  def users.create_labeled(label, **o) = create(label, **o)
-
-  section :stems
-  section :leafs
-  def plans.upsert(*, unique_by: :title, **o) = super
-
-  section do
-    seed :accounts, :data
-  end
-end
+Oaken.seed :setup, :accounts, :data

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,3 +1,3 @@
 ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV["VERBOSE"] || ENV["CI"]
 
-Oaken.seed :setup, :accounts, :data
+Oaken.seed :accounts, :data

--- a/test/dummy/db/seeds/accounts/kaspers_donuts.rb
+++ b/test/dummy/db/seeds/accounts/kaspers_donuts.rb
@@ -1,21 +1,18 @@
-section :accounts
-donuts = accounts.create :kaspers_donuts, name: "Kasper's Donuts"
+section :account # This is our default account setup that's used for authenticating in integration/system tests.
+account = accounts.create :kaspers_donuts, name: "Kasper's Donuts"
 
-section :users
-kasper   = users.create :kasper,   name: "Kasper",   email_address: "kasper@example.com",   accounts: [donuts]
-coworker = users.create :coworker, name: "Coworker", email_address: "coworker@example.com", accounts: [donuts]
+kasper   = users.create :kasper,   name: "Kasper",   email_address: "kasper@example.com",   accounts: [account]
+coworker = users.create :coworker, name: "Coworker", email_address: "coworker@example.com", accounts: [account]
 
 administratorships.label kasper_administratorship: kasper.administratorships.first
 
-section :menus, :with_items
-menu = menus.create account: donuts
-plain_donut     = menu_items.create menu: menu, name: "Plain",     price_cents: 10_00
-sprinkled_donut = menu_items.create menu: menu, name: "Sprinkled", price_cents: 10_10
+menu = menus.create(account:)
+plain_donut     = menu_items.create menu:, name: "Plain",     price_cents: 10_00
+sprinkled_donut = menu_items.create menu:, name: "Sprinkled", price_cents: 10_10
 menus.label basic: menu
 
 menu_item_details.create :plain, menu_item: plain_donut, description: "Plain, but mighty."
 
-section :orders
 supporter = users.create name: "Super Supporter"
 orders.insert_all [user_id: supporter.id, item_id: plain_donut.id] * 10
 

--- a/test/dummy/db/seeds/setup.rb
+++ b/test/dummy/db/seeds/setup.rb
@@ -1,0 +1,9 @@
+Oaken.defaults name: -> { "Shouldn't be used for users.name" }, title: -> { "Global Default Title" }
+
+user_counter, email_address_counter = 0, 0
+users.defaults name: -> { "Customer #{user_counter += 1}" },
+  email_address: -> { "email_address#{email_address_counter += 1}@example.com" }
+def users.create(*, unique_by: :email_address, **o) = super
+def users.create_labeled(label, **o) = create(label, **o)
+
+def plans.upsert(*, unique_by: :title, **o) = super

--- a/test/dummy/db/seeds/setup.rb
+++ b/test/dummy/db/seeds/setup.rb
@@ -1,4 +1,4 @@
-Oaken.defaults name: -> { "Shouldn't be used for users.name" }, title: -> { "Global Default Title" }
+loader.defaults name: -> { "Shouldn't be used for users.name" }, title: -> { "Global Default Title" }
 
 user_counter, email_address_counter = 0, 0
 users.defaults name: -> { "Customer #{user_counter += 1}" },

--- a/test/dummy/test/models/oaken/loader/type_test.rb
+++ b/test/dummy/test/models/oaken/loader/type_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 
-class Oaken::TypeTest < ActiveSupport::TestCase
+class Oaken::Loader::TypeTest < ActiveSupport::TestCase
   test "with zero segments" do
-    type = Oaken::Type.for("users")
+    type = Oaken::Loader::Type.for("users")
 
     assert_consts type, ["User"]
     assert_equal User, type.locate
   end
 
   test "with one segment" do
-    type = Oaken::Type.for("menu_items")
+    type = Oaken::Loader::Type.for("menu_items")
 
     assert_consts type, [
       "Menu::Item",
@@ -19,7 +19,7 @@ class Oaken::TypeTest < ActiveSupport::TestCase
   end
 
   test "with two segments" do
-    type = Oaken::Type.for("menu_item_details")
+    type = Oaken::Loader::Type.for("menu_item_details")
 
     assert_consts type, [
       "Menu::Item::Detail",
@@ -31,7 +31,7 @@ class Oaken::TypeTest < ActiveSupport::TestCase
   end
 
   test "with three segments" do
-    type = Oaken::Type.for("menu_item_detail_segments")
+    type = Oaken::Loader::Type.for("menu_item_detail_segments")
 
     assert_consts type, [
       "Menu::Item::Detail::Segment",
@@ -48,7 +48,7 @@ class Oaken::TypeTest < ActiveSupport::TestCase
 
   test "with four segments" do
     error = assert_raises ArgumentError do
-      Oaken::Type.for("this_has_four_segments_total").possible_consts.to_a
+      Oaken::Loader::Type.for("this_has_four_segments_total").possible_consts.to_a
     end
     assert_match /can't resolve this_has_four_segments_total to an object/, error.message
   end

--- a/test/dummy/test/models/oaken/loader_test.rb
+++ b/test/dummy/test/models/oaken/loader_test.rb
@@ -2,8 +2,7 @@ require "test_helper"
 
 class Oaken::LoaderTest < ActiveSupport::TestCase
   test "attr_readers" do
-    assert_equal Pathname("db/seeds"), Oaken.loader.root
-    assert_equal [".", "test"], Oaken.loader.subpaths
+    assert_equal ["db/seeds", "db/seeds/test"], Oaken.loader.lookup_paths
     assert_equal Oaken::Seeds, Oaken.loader.context
   end
 
@@ -13,16 +12,19 @@ class Oaken::LoaderTest < ActiveSupport::TestCase
     assert_includes paths, "db/seeds/accounts/kaspers_donuts.rb"
   end
 
-  test "with" do
-    context = Module.new
-    loader = Oaken.with(root: "test/seeds", subpaths: "cases", context:)
-    assert_equal Pathname("test/seeds"), loader.root
-    assert_equal [".", "cases"], loader.subpaths
-    assert_equal context, loader.context
+  test "with + lookup_paths" do
+    loader = Oaken.with(lookup_paths: "test/seeds")
+    assert_equal ["test/seeds"], loader.lookup_paths
+    assert_equal ["db/seeds", "db/seeds/test"], Oaken.loader.lookup_paths
 
-    # Ensure we don't clobber settings
-    assert_equal Pathname("db/seeds"), Oaken.loader.root
-    assert_equal [".", "test"], Oaken.loader.subpaths
+    loader.with.tap { _1.lookup_paths.clear }
+    assert_equal ["test/seeds"], loader.lookup_paths
+  end
+
+  test "with + context" do
+    context = Module.new
+    loader = Oaken.with(lookup_paths: "test/seeds", context:)
+    assert_equal context, loader.context
     assert_equal Oaken::Seeds, Oaken.loader.context
   end
 

--- a/test/dummy/test/models/oaken/loader_test.rb
+++ b/test/dummy/test/models/oaken/loader_test.rb
@@ -7,6 +7,12 @@ class Oaken::LoaderTest < ActiveSupport::TestCase
     assert_equal Oaken::Seeds, Oaken.loader.context
   end
 
+  test "glob" do
+    paths = Oaken.glob(:accounts).map(&:to_s)
+    assert_includes paths, "db/seeds/accounts/demo.rb"
+    assert_includes paths, "db/seeds/accounts/kaspers_donuts.rb"
+  end
+
   test "with" do
     context = Module.new
     loader = Oaken.with(root: "test/seeds", subpaths: "cases", context:)

--- a/test/dummy/test/models/oaken/loader_test.rb
+++ b/test/dummy/test/models/oaken/loader_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class Oaken::LoaderTest < ActiveSupport::TestCase
+  test "attr_readers" do
+    assert_equal Pathname("db/seeds"), Oaken.loader.root
+    assert_equal [".", "test"], Oaken.loader.subpaths
+    assert_equal Oaken::Seeds, Oaken.loader.context
+  end
+
+  test "with" do
+    context = Module.new
+    loader = Oaken.with(root: "test/seeds", subpaths: "cases", context:)
+    assert_equal Pathname("test/seeds"), loader.root
+    assert_equal [".", "cases"], loader.subpaths
+    assert_equal context, loader.context
+
+    # Ensure we don't clobber settings
+    assert_equal Pathname("db/seeds"), Oaken.loader.root
+    assert_equal [".", "test"], Oaken.loader.subpaths
+    assert_equal Oaken::Seeds, Oaken.loader.context
+  end
+
+  test "with + defaults don't carry over" do
+    loader = Oaken.with.tap { _1.defaults name: "Someone" }
+    assert_empty loader.with.defaults
+  end
+
+  test "with + locator" do
+    locator = Class.new { attr_accessor :located; alias_method :locate, :located= }.new
+    Oaken.with(locator:).locate(:accounts)
+    assert_equal locator.located, :accounts
+  end
+
+  test "with + provider" do
+    context = Module.new
+    provider = Struct.new(:loader, :type)
+    loader = Oaken.with(provider:, context:).tap { _1.register User }
+
+    instance = Class.new.include(loader.context).new
+    assert_respond_to instance, :users
+    assert_kind_of provider, instance.users
+    assert_equal loader, instance.users.loader
+    assert_equal User, instance.users.type
+  end
+end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -6,8 +6,8 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "replacing loader" do
-    old_loader, Oaken.loader = Oaken.loader, Oaken.with(root: name)
-    assert_equal name, Oaken.root.to_s
+    old_loader, Oaken.loader = Oaken.loader, Oaken.with(lookup_paths: name)
+    assert_equal [name], Oaken.lookup_paths
   ensure
     Oaken.loader = old_loader
   end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -5,6 +5,13 @@ class OakenTest < ActiveSupport::TestCase
     refute_nil ::Oaken::VERSION
   end
 
+  test "replacing loader" do
+    old_loader, Oaken.loader = Oaken.loader, Oaken.with(root: name)
+    assert_equal name, Oaken.root.to_s
+  ensure
+    Oaken.loader = old_loader
+  end
+
   test "accessing fixture" do
     assert_equal "Kasper", users.kasper.name
     assert_equal "Coworker", users.coworker.name

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -98,7 +98,7 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "can't use labels within tests" do
-    assert_raise ArgumentError do
+    assert_raise ArgumentError, match: /define labelled records outside of tests/ do
       users.label kasper_2: users.kasper
     end
   end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -125,11 +125,11 @@ class OakenTest < ActiveSupport::TestCase
   end
 
   test "raises when no files found to seed" do
-    assert_raise(Oaken::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
+    assert_raise(Oaken::Loader::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
       assert_match %r|found no seed files for "test/cases/missing"|, error.message
     end
 
-    assert_raise(Oaken::NoSeedsFoundError) { seed :first_missing, :second_missing }.tap do |error|
+    assert_raise(Oaken::Loader::NoSeedsFoundError) { seed :first_missing, :second_missing }.tap do |error|
       assert_match /found no seed files for :first_missing/, error.message
     end
   end

--- a/test/dummy/test/test_helper.rb
+++ b/test/dummy/test/test_helper.rb
@@ -7,5 +7,5 @@ ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV["VERBOSE"] || ENV["CI"]
 class ActiveSupport::TestCase
   parallelize workers: :number_of_processors, threshold: ENV.fetch("PARALLEL_TEST_THRESHOLD", 5).to_i
 
-  prepend Oaken.test_setup
+  include Oaken.test_setup
 end

--- a/test/dummy/test/test_helper.rb
+++ b/test/dummy/test/test_helper.rb
@@ -7,5 +7,5 @@ ActiveRecord::Base.logger = Logger.new(STDOUT) if ENV["VERBOSE"] || ENV["CI"]
 class ActiveSupport::TestCase
   parallelize workers: :number_of_processors, threshold: ENV.fetch("PARALLEL_TEST_THRESHOLD", 5).to_i
 
-  include Oaken::TestSetup
+  prepend Oaken.test_setup
 end


### PR DESCRIPTION
This implements what's documented in the README in #112.

```md
### How to upgrade

`Oaken.prepare` doesn't exist anymore.

So if you have:

\`\`\`ruby
# db/seeds.rb
Oaken.prepare do
  defaults name: -> { "Some name" }
  users.defaults name: -> { "Some override" }

  def users.some_helper = nil

  seed :accounts, :data
end
\`\`\`

Replace it with:

\`\`\`ruby
# db/seeds.rb
Oaken.seed :accounts, :data

# db/seeds/setup.rb # You can nest this more deeply too, see the README.
loader.defaults name: -> { "Some name" } # Notice `loader` here, we don't have bare `defaults` calls anymore.
users.defaults name: -> { "Some override" }

def users.some_helper = nil
\`\`\`

- [ ] Reread the README.
- [ ] Replace `Oaken.prepare` as mentioned above.
- [ ] Replace bare `defaults` in `Oaken.prepare` with `loader.defaults`
- [ ] Replace `include Oaken::TestSetup` with `include Oaken.loader.test_setup`
```