### PR TITLE
Remove raising when no seeds are found

### DIFF
--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Oaken::Loader
-  class NoSeedsFoundError < ArgumentError; end
-
   autoload :Type, "oaken/loader/type"
 
   attr_reader :lookup_paths, :locator, :provider, :context
@@ -75,7 +73,7 @@ class Oaken::Loader
   def seed(*identifiers)
     setup
 
-    identifiers.flat_map { glob! _1 }.each { load_one _1 }
+    identifiers.flat_map { glob _1 }.each { load_one _1 }
     self
   end
 
@@ -90,10 +88,6 @@ class Oaken::Loader
 
   private
     def setup = @setup ||= glob(:setup).each { load_one _1 }
-
-    def glob!(identifier)
-      glob(identifier).then.find(&:any?) or raise NoSeedsFoundError, "found no seed files for #{identifier.inspect}"
-    end
 
     def load_one(path)
       context.class_eval path.read, path.to_s

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -130,14 +130,4 @@ class OakenTest < ActiveSupport::TestCase
     assert mod.respond_to?(:users) # Now respond_to_missing? hits.
     refute mod.respond_to?(:hmhm)
   end
-
-  test "raises when no files found to seed" do
-    assert_raise(Oaken::Loader::NoSeedsFoundError) { seed "test/cases/missing" }.tap do |error|
-      assert_match %r|found no seed files for "test/cases/missing"|, error.message
-    end
-
-    assert_raise(Oaken::Loader::NoSeedsFoundError) { seed :first_missing, :second_missing }.tap do |error|
-      assert_match /found no seed files for :first_missing/, error.message
-    end
-  end
 end


### PR DESCRIPTION
In https://github.com/kaspth/oaken/pull/99 we attempted to catch typos, so we wouldn't fail silently in case there's no seeds anywhere.

This turns out to have an unintended consequence that prevent people from having seed files for some environments.

That goes against Oaken's design so fixing it takes precedence.

I didn't have time to figure out how to keep the typo prevention just yet. I may bring it back later.

Fixes https://github.com/kaspth/oaken/issues/116
Fixes https://github.com/kaspth/oaken/issues/121