### PR TITLE
Remove reliance on Rails' `Kernel#class_eval` core extension

### DIFF
--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -7,7 +7,7 @@ class Oaken::Stored::ActiveRecord
 
   def initialize(loader, type)
     @loader, @type = loader, type
-    @original_label_target = self # Capture original self so labels made during `with` calls, retarget original.
+    @original_label_target = singleton_class # Capture original self so labels made during `with` calls, retarget original.
     @attributes = loader.defaults_for(*type.column_names)
   end
 


### PR DESCRIPTION
Apparently Rails adds a `Kernel#class_eval` extension that delegates to `singleton_class.class_eval`.

Rather than rely on that we can just use singleton_class as the label target.