### PR TITLE
Require the Rails extensions we're using

### DIFF
--- a/lib/oaken.rb
+++ b/lib/oaken.rb
@@ -3,6 +3,8 @@
 require "oaken/version"
 require "pathname"
 
+require "active_support/core_ext/module/delegation"
+
 module Oaken
   class Error < StandardError; end
 

--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/hash/indifferent_access"
+
 class Oaken::Loader
   autoload :Type, "oaken/loader/type"
 


### PR DESCRIPTION
I probably should remove these eventually.