### PR TITLE
Add `new`/`build` to instantiate records with defaults applied.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,22 @@ Typically used for data tables, like so:
 plans.upsert :basic, unique_by: :title, title: "Basic", price_cents: 10_00
 ```
 
+#### `new`/`build`
+
+We've also got `new`/`build` in case you:
+
+- have a record that needs slightly more complex setup so you can't do `create`/`upsert`.
+- want a record that's not in the database during testing.
+
+Will have defaults applied via `attributes_for` internally.
+
+```ruby
+test "some test" do
+  user = users.new name: "Someone"
+  user = users.build name: "Someone"
+end
+```
+
 #### Using `defaults`
 
 You can set `defaults` that're applied on `create`/`upsert`, like this:

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -33,6 +33,12 @@ class Oaken::Stored::ActiveRecord
     record
   end
 
+  # Build a new record with the passed `attributes`.
+  def new(**attributes)
+    type.new(**attributes_for(**attributes))
+  end
+  alias_method :build, :new
+
   # Build attributes used for `create`/`upsert`, applying loader and per-type `defaults`.
   #
   #   loader.defaults name: -> { "Global" }, email_address: -> { … }

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -90,6 +90,36 @@ class OakenTest < ActiveSupport::TestCase
     end
   end
 
+  test """new:
+    - uses global defaults with procs
+    - allows overriding global defaults
+  """ do
+    users.new(email_address: "user@example.com").tap do |user|
+      assert_match /Customer \d+/, user.name
+      assert_equal "user@example.com", user.email_address
+    end
+
+    plans.new(price_cents: 10_00).tap do |plan|
+      assert_equal "Global Default Title", plan.title
+      assert_equal 10_00, plan.price_cents
+    end
+  end
+
+  test """build:
+    - uses global defaults with procs
+    - allows overriding global defaults
+  """ do
+    users.build(email_address: "user@example.com").tap do |user|
+      assert_match /Customer \d+/, user.name
+      assert_equal "user@example.com", user.email_address
+    end
+
+    plans.build(price_cents: 10_00).tap do |plan|
+      assert_equal "Global Default Title", plan.title
+      assert_equal 10_00, plan.price_cents
+    end
+  end
+
   test "source attribution" do
     donuts_location, kasper_location = [accounts.method(:kaspers_donuts), users.method(:kasper)].map(&:source_location)
     assert_match "db/seeds/accounts/kaspers_donuts.rb", donuts_location.first


### PR DESCRIPTION
I think this makes sense and is easy enough to support.

### README update

We've also got `new`/`build` in case you:

- have a record that needs slightly more complex setup so you can't do `create`/`upsert`.
- want a record that's not in the database during testing.

Will have defaults applied via `attributes_for` internally.

```ruby
test "some test" do
  user = users.new name: "Someone"
  user = users.build name: "Someone"
end
```

Closes https://github.com/kaspth/oaken/issues/119