### PR TITLE
Print oaken-main when reporting loc

### DIFF
--- a/bin/loc
+++ b/bin/loc
@@ -1,9 +1,14 @@
 #!/usr/bin/env ruby
 
-require_relative "../lib/oaken/version"
+oaken_version = "oaken-main"
+
+if ARGV.delete "--use-version"
+  require_relative "../lib/oaken/version"
+  oaken_version = "oaken-#{Oaken::VERSION}"
+end
 
 # To setup dependencies run with: bin/loc --install
-if ARGV.delete("--install")
+if ARGV.delete "--install"
   system "brew install cloc"
   system "gem install activerecord factory_bot fabrication test_data --no-doc"
 end
@@ -24,5 +29,5 @@ report "fabrication"
 report "test_data"
 
 dir = File.expand_path("lib")
-puts dir.sub("oaken", "oaken-#{Oaken::VERSION}")
+puts dir.sub("oaken", oaken_version)
 Dir.chdir(dir) { cloc "." }

--- a/bin/loc-table
+++ b/bin/loc-table
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-lines = `bin/loc --csv`.split("\n")
+lines = `bin/loc #{ARGV.join(" ")} --csv`.strip.split("\n")
 lines.select! { _1.include?("SUM") || _1.match?(/[a-z]+$/) }
 
 rows = lines.each_slice(2).map do |path, row|


### PR DESCRIPTION
Can now also run:

```
bin/loc --use-version
bin/loc-table --use-version
```

To print the current Oaken version instead of oaken-main.

gem | files | loc
 -- | ----- | --
| activerecord-8.1.0 | 8 | 848 |
| factory_bot-6.5.6 | 53 | 2088 |
| fabrication-3.0.0 | 29 | 1123 |
| test_data-0.3.2 | 44 | 1297 |
| oaken-main | 10 | 274 |