### PR TITLE
Allow labels in tests

### DIFF
--- a/lib/oaken/loader.rb
+++ b/lib/oaken/loader.rb
@@ -83,16 +83,17 @@ class Oaken::Loader
     Pathname.glob lookup_paths.map { File.join _1, "#{identifier}{,/**/*}.rb" }
   end
 
-  def definition_location
-    # The first line referencing LABEL happens to be the line in the seed file.
-    caller_locations(3, 6).find { _1.base_label == LABEL }
+  def definition_location(start_frame:)
+    # Locate first frame not in `setup` phase. Rely on caller adjusting frame start to skip over their stack levels.
+    # Won't skip over helpers defined in non-setup seed files, though that's probably ok.
+    caller_locations(1 + start_frame, 4).find { !setup_files.member? _1.path }
   end
 
   private
+    def setup_files = @setup_files ||= setup.map(&:to_s).to_set
     def setup = @setup ||= glob(:setup).each { load_one _1 }
 
     def load_one(path)
       context.class_eval path.read, path.to_s
     end
-    LABEL = instance_method(:load_one).name.to_s
 end

--- a/lib/oaken/stored/active_record.rb
+++ b/lib/oaken/stored/active_record.rb
@@ -5,10 +5,14 @@ class Oaken::Stored::ActiveRecord
   delegate :transaction, to: :type # For multi-db setups to help open a transaction on secondary connections.
   delegate :find, :insert_all, :pluck, to: :type
 
+  attr_reader :labels
+
   def initialize(loader, type)
     @loader, @type = loader, type
-    @original_label_target = singleton_class # Capture original self so labels made during `with` calls, retarget original.
     @attributes = loader.defaults_for(*type.column_names)
+
+    @labels = {}
+    @label_target = singleton_class # Capture target so labels in `with` calls go to our original instance.
   end
 
   # Create a record in the database with the passed `attributes`.
@@ -150,12 +154,17 @@ class Oaken::Stored::ActiveRecord
   #   users.label someone:, someone_else:
   #
   # Note: `users.method(:someone).source_location` also points back to the file and line of the `label` call.
-  def label(**labels) = labels.each { |label, record| _label label, record.id }
+  def label(**labels) = labels.each { |label, record| _label label, record.id, location_frame_skip: 2 }
 
-  private def _label(name, id)
-    location = @loader.definition_location or
-      raise ArgumentError, "you can only define labelled records outside of tests"
+  private def _label(name, id, location_frame_skip: 0)
+    labels.fetch name do
+      loc = loader.definition_location(start_frame: 4 + location_frame_skip) or
+        raise "Oaken can't find a source_location for this label: #{name}. Please open an issue and share what you're trying and a backtrace if you can."
 
-    @original_label_target.class_eval "def #{name} = find(#{id.inspect})", location.path, location.lineno
+      label_target.class_eval "def #{name} = find(labels.fetch(__method__))", loc.path, loc.lineno
+    end
+
+    labels[name] = id
   end
+  private attr_reader :label_target
 end

--- a/test/dummy/test/models/oaken_test.rb
+++ b/test/dummy/test/models/oaken_test.rb
@@ -138,7 +138,10 @@ class OakenTest < ActiveSupport::TestCase
 
   test "proxy" do
     assert_equal users.named_coworker.type.first, users.coworker
+    assert_equal users.singleton_class, users.named_coworker.send(:label_target)
+
     assert_equal users.mod.named_coworker.type.first, users.coworker
+    assert_equal users.singleton_class, users.mod.named_coworker.send(:label_target)
   end
 
   test "with - labeled via helper method" do
@@ -177,9 +180,17 @@ class OakenTest < ActiveSupport::TestCase
     assert_match /email_address\d+@example\.com/, user.email_address
   end
 
-  test "can't use labels within tests" do
-    assert_raise ArgumentError, match: /define labelled records outside of tests/ do
-      users.label kasper_2: users.kasper
+  test "labels in tests allow overrides" do
+    first_test_user = users.create :in_test, name: "First"
+    assert_equal first_test_user, users.in_test
+
+    # Move `:in_test` "pointer" ownership to another user
+    second_test_user = users.create :in_test, name: "Second"
+    assert_equal second_test_user, users.in_test
+    refute_equal first_test_user, second_test_user
+
+    administratorships.labels.fetch(:kasper_administratorship).tap do |composite_id|
+      assert_equal [accounts.kaspers_donuts.id, users.kasper.id], composite_id
     end
   end
 


### PR DESCRIPTION
For RSpec users, in particular, to avoid subtle database bugs where methods haven't saved data and tests don't catch that.

Consider a case like this:

```ruby
let(:someone) { users.create name: "Person" }

it "persists renames" do
  someone.rename_to "Doppelganger"
  expect(someone.name).to == "Doppelganger"
end
```

If `rename_to` didn't call `save!`/`update!` to persist the data but just set the name, our test would pass because of `let`'s caching. The fix is to remember to call `someone.reload.name`.

However, now users can do:

```ruby
before { users.create :someone, name: "Person" }

it "persists renames" do
  users.someone.rename_to "Doppelganger"
  expect(users.someone.name).to == "Doppelganger"
end
```

Because Oaken always reloads when you call e.g. `users.someone` the bug is prevented automatically.

---

Internally, we'll now track `labels` in a Hash, so `users.labels` contains all the labels the users know about.

We'll also correctly identify the `source_location` for the label created in the test, so `users.method(:someone).source_location` works.

Essentially, we're creating the reader method `users.someone` on the first call to `users.create :someone`, but then we allow the next run to change the underlying id pointer that `users.someone` points to.

There'll be spurious test failures if you override labels in tests that you've created in db/seeds. I don't know how to handle that yet, so I'll delegate that to further work later.