### PR TITLE
fix: Failing CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - "8.1"
           - "main"
         ruby:
-          - "3.2"
+          - "3.3"
           - "4.0"
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Hi all :wave:

I noticed the CI was failing on your main branch because it's using Ruby 3.2 and 4.0, but rails-main requires 3.3.1 or higher.

See [https://github.com/rails/rails/blob/main/rails.gemspec](https://github.com/rails/rails/blob/main/rails.gemspec), it currently includes:

```ruby
Gem::Specification.new do |s|
  s.required_ruby_version     = ">= 3.3.1"
end
```

---

I've also checked the other Rails versions the CI tests against; 7.2(.3.2), 8.0(.5.1) and 8.1(.3.1); while they *require* lower Ruby versions, they also *permit* Ruby 3.3 and up.